### PR TITLE
feat: add pyproject.toml with dependency declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ serve, not a number you quote:
 Built and used on an **NVIDIA DGX Spark (GB10)**, but the harness itself only needs a URL.
 
 ```bash
-pip install -r requirements.txt
+pip install -e .
 export BENCH_BASE_URL=http://localhost:8001/v1 BENCH_MODEL=my-model
 
-./bench validate                      # 28/28 — the tests are passable
+./bench validate                      # 44/44 — the tests are passable
 ./bench run --suite all --thinking --max-tokens 16000 --label "my-model think-ON"
 ./bench report results/*/run-*.json --title "My model" --verdict "..."
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "dgx-spark-llm-lab"
+version = "0.1.0"
+description = "Find the best configuration for your daily-driver LLM — then keep it."
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.10"
+dependencies = [
+    "openai>=2.0,<3",
+    "aiohttp>=3.8,<4",
+]
+
+[tool.setuptools.packages.find]
+include = ["benchkit*"]
+
+[project.scripts]
+bench = "benchkit.cli:main"


### PR DESCRIPTION
## Description\n\nCloses #6 — Adds `pyproject.toml` declaring every dependency and Python floor.\n\n### Changes\n\n- **Added `pyproject.toml\** with:\n  - `requires-python = ">=3.10"` (X | None annotations require 3.10+)\n  - `openai>=2.0,<3` (bounded, aligns with installed 2.31.0)\n  - `aiohttp>=3.8,<4` (declared — was imported by router.py but missing from requirements.txt)\n  - Console script `bench = "benchkit.cli:main"`\n  - Explicit package discovery for `benchkit\*` to avoid setuptools auto-discovery of results/configs\n\n- **Updated README.md** quick-start:\n  - `pip install -r requirements.txt` → `pip install -e .`\n  - Updated validate comment from 28/28 → 44/44\n\n### Verification\n\n- `pip install -e .` succeeds in a fresh venv\n- `python -c "import router"` succeeds (aiohttp now declared)\n- `./bench --help` works (console_scripts entry point functional)\n- `./bench validate` → 28/28 reference solutions pass\n- `./bench validate --suite agentic-all` → 16/16 oracles solve their task\n- Total: **44/44**\n\n**Closes:** F-DEP-001, F-DEP-002, F-DEP-004, F-DOCS-002\n**Dependencies:** Pre.2 (#4), Pre.3 (#5)