### PR TITLE
fix: clear all ruff and mypy errors in benchkit

### DIFF
--- a/benchkit/agentic/env.py
+++ b/benchkit/agentic/env.py
@@ -60,7 +60,7 @@ class Workspace:
             raise ToolError(f"no such file: {path}. Use list_files to see what exists.")
         body = self.files[path]
         lines = body.splitlines()
-        return "\n".join(f"{i:>4}| {l}" for i, l in enumerate(lines, 1))[:MAX_OUTPUT]
+        return "\n".join(f"{i:>4}| {line}" for i, line in enumerate(lines, 1))[:MAX_OUTPUT]
 
     def write_file(self, path, content):
         path = path.strip("/")

--- a/benchkit/harness/__init__.py
+++ b/benchkit/harness/__init__.py
@@ -2,7 +2,10 @@
 
 See benchkit/harness/base.py for why this exists and ROADMAP.md for what is next.
 """
-from .base import Harness, HarnessResult, run_task
+__all__ = ["Harness", "HarnessResult", "run_task", "PiHarness", "OpenCodeHarness",
+           "ClaudeCodeHarness", "HARNESSES", "get"]
+
+from .base import Harness as Harness, HarnessResult as HarnessResult, run_task as run_task
 from .pi import PiHarness
 from .opencode import OpenCodeHarness
 from .claudecode import ClaudeCodeHarness

--- a/benchkit/harness/base.py
+++ b/benchkit/harness/base.py
@@ -57,7 +57,7 @@ class Harness:
         return container
 
     #: files the harness writes into the workspace that are not part of the task
-    excluded_files = ()
+    excluded_files: tuple[str, ...] = ()
 
     def run(self, workdir, prompt, timeout=900, thinking=False):
         raise NotImplementedError

--- a/benchkit/harness/claudecode.py
+++ b/benchkit/harness/claudecode.py
@@ -231,7 +231,7 @@ class ClaudeCodeHarness(Harness):
         res = parse_events(p.stdout)
         if p.returncode != 0 and not res.error:
             res.stop_reason = "error"
-            tail = [l for l in (p.stderr or "").strip().splitlines() if l.strip()]
+            tail = [line for line in (p.stderr or "").strip().splitlines() if line.strip()]
             res.error = tail[-1][:200] if tail else f"exit {p.returncode}"
         return res
 

--- a/benchkit/report.py
+++ b/benchkit/report.py
@@ -60,7 +60,7 @@ def _chart(title, y_label, categories, values, y_max=None, kind="bar"):
 def build(runs, title, question=None, verdict=None, notes=None, short_labels=None):
     """runs: list of loaded result dicts. Returns Markdown source."""
     labels = [_label(r) for r in runs]
-    short = short_labels or [_short(r, l) for r, l in zip(runs, labels)]
+    short = short_labels or [_short(r, line) for r, line in zip(runs, labels)]
     S = [r["summary"] for r in runs]
 
     out = [f"# {title}\n"]
@@ -122,7 +122,7 @@ def build(runs, title, question=None, verdict=None, notes=None, short_labels=Non
     else:
         out.append(f"| Samples per task | {samples} |")
     out.append(f"| Concurrency | {conc} |")
-    out.append(f"| Metric | pass@1 over hidden executable unit tests |\n")
+    out.append("| Metric | pass@1 over hidden executable unit tests |\n")
     if not (conc_same and samples_same):
         out.append("<sub>The runs above were **not** all collected under the same settings. "
                    "Solve rate and tool-call counts are unaffected, but wall-clock is not "
@@ -215,7 +215,7 @@ def build(runs, title, question=None, verdict=None, notes=None, short_labels=Non
                '    title "pass@1 by difficulty (%)"\n'
                '    x-axis ["easy", "medium", "hard"]\n'
                '    y-axis "pass@1 %" 0 --> 100\n' + lines + "\n```\n")
-    out.append("<sub>" + " · ".join(f"Line {i+1} = {l}" for i, l in enumerate(labels)) + "</sub>\n")
+    out.append("<sub>" + " · ".join(f"Line {i+1} = {line}" for i, line in enumerate(labels)) + "</sub>\n")
 
     # --- per-task disagreement between best and runner-up ---
     if len(S) >= 2:
@@ -258,7 +258,7 @@ def build(runs, title, question=None, verdict=None, notes=None, short_labels=Non
         out.append("- A truncated generation counts as a failure; a high `Truncated` column means "
                    "runaway reasoning, which hangs real agents.")
     out.append("\n## Raw data\n")
-    for r, l in zip(runs, labels):
-        out.append(f"- `{r['_path']}` — {l}")
+    for r, line in zip(runs, labels):
+        out.append(f"- `{r['_path']}` — {line}")
     out.append("")
     return "\n".join(out)

--- a/tests/test_config_files.py
+++ b/tests/test_config_files.py
@@ -43,7 +43,7 @@ class TestEnvExample(unittest.TestCase):
     def test_has_comments(self):
         """Every variable must have a descriptive comment (line starting with #)."""
         lines = self.content.splitlines()
-        var_lines = [l for l in lines if re.match(r"^\w+=", l)]
+        var_lines = [line for line in lines if re.match(r"^\w+=", line)]
         for var_line in var_lines:
             var_name = var_line.split("=")[0].strip()
             # There should be a comment line (starting with #) within a few lines


### PR DESCRIPTION
## Description

Fix the 9 remaining ruff errors and the single mypy error:

- **E741** — ambiguous variable name `l` at five sites (renamed to `line`):
  - `benchkit/agentic/env.py:63` — `read_file` output formatting
  - `benchkit/harness/claudecode.py:234` — stderr tail parsing
  - `benchkit/report.py:63` — short label comprehension
  - `benchkit/report.py:218` — mermaid line labels
  - `benchkit/report.py:261` — raw data listing
  - `tests/test_config_files.py:46` — env var line filtering
- **F401** — unused re-exports in `benchkit/harness/__init__.py` (added `__all__` + explicit `X as X` aliases)
- **F541** — f-string without placeholders in `benchkit/report.py:125` (removed `f` prefix)
- **mypy** — `benchkit/harness/opencode.py:72` incompatible types in `excluded_files` assignment (fixed base class type annotation in `benchkit/harness/base.py:60`)

## Acceptance Criteria

- [x] `ruff check .` reports 0 errors
- [x] `mypy benchkit router.py --ignore-missing-imports` reports 0 errors
- [x] `benchkit/harness/base.py:60` declares `excluded_files: tuple[str, ...] = ()`
- [x] `./bench validate` passes 28/28
- [x] `./bench validate --suite agentic-all` passes 16/16

## Closes

F-BUG-009, F-CLEAN-005, F-CLEAN-006, F-CLEAN-007

**Dependencies:** 0.3 (#8)