### PR TITLE
ci: add pre-commit hooks for ruff and mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,32 @@
+# pre-commit hooks for ruff (linting) and mypy (type checking)
+# Scoped to benchkit/ and router.py — the active source tree.
+
+default_language_version:
+  python: python3
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+        exclude: results/
+      - id: end-of-file-fixer
+        exclude: results/
+      - id: check-yaml
+        exclude: results/
+      - id: check-added-large-files
+        exclude: results/
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.9
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+        files: ^benchkit/|router\.py$
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.13.0
+    hooks:
+      - id: mypy
+        additional_dependencies: []
+        files: ^benchkit/|router\.py$


### PR DESCRIPTION
## Description

Closes #11 · Resolves F-CI-002

Adds pre-commit hooks for automated linting (ruff) and type-checking (mypy) scoped to `benchkit/` and `router.py`.

## Acceptance Criteria

- [x] `\.pre-commit-config.yaml` exists with ruff and mypy hooks scoped to `benchkit/` and `router.py`
- [x] `pre-commit run --all-files` exits 0
- [x] `./bench validate && ./bench validate --suite agentic-all` passes 44/44

## Changes

- Added `.pre-commit-config.yaml` with:
  - pre-commit-hooks (trailing-whitespace, end-of-file, check-yaml, check-added-large-files) excluding `results/`
  - ruff-pre-commit v0.6.9 for `benchkit/` and `router.py`
  - mirrors-mypy v1.13.0 for `benchkit/` and `router.py`