### PR TITLE
test: add coverage reporting for benchkit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,13 @@ jobs:
       - name: Run mypy
         run: uv run mypy benchkit router.py --ignore-missing-imports
 
-      - name: Run bench validate
-        run: uv run ./bench validate
+      - name: Run bench validate with coverage
+        run: uv run coverage run --source=benchkit --parallel-mode -m benchkit.cli validate
 
-      - name: Run bench validate agentic-all
-        run: uv run ./bench validate --suite agentic-all
+      - name: Run bench validate agentic-all with coverage
+        run: uv run coverage run --source=benchkit --parallel-mode -m benchkit.cli validate --suite agentic-all
+
+      - name: Combine and report coverage
+        run: |
+          uv run coverage combine
+          uv run coverage report

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,11 +25,22 @@ target-version = "py310"
 exclude = ["results/"]
 line-length = 100
 
+[tool.coverage.run]
+source = ["benchkit"]
+branch = true
+parallel = true
+
+[tool.coverage.report]
+show_missing = true
+skip_empty = true
+fail_under = 0
+
 [tool.mypy]
 exclude = ["results/"]
 
 [dependency-groups]
 dev = [
+    "coverage[toml]>=7.0",
     "mypy>=2.3.1",
     "ruff==0.6.9",
 ]


### PR DESCRIPTION
Add coverage reporting to CI so that benchkit test coverage is measurable and reproducible.

**Closes:** #12

## Changes
- **pyproject.toml**: Added `[tool.coverage.run]` and `[tool.coverage.report]` sections with `source = ["benchkit"]`, `branch = true`, `show_missing = true`. Added `coverage[toml]` to dev dependencies.
- **CI workflow**: Replaced `./bench validate` steps with coverage-instrumented runs using `coverage run --source=benchkit --parallel-mode`, plus a final `coverage combine && coverage report` step.

## Acceptance Criteria
- [x] `pyproject.toml` contains a `[tool.coverage]` section with `source = ["benchkit"]`
- [x] CI runs coverage over both validate suites and prints a total
- [x] `./bench validate && ./bench validate --suite agentic-all` passes at 44/44