### PR TITLE
feat(harness): add an endpoint mode to the pi harness (#56)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,7 +40,8 @@ BENCH_HARNESS_MODEL=
 
 # OpenAI-compatible endpoint to point a harness at for the run, instead of using
 # the providers it already has configured. Opt-in: leave unset to benchmark your
-# existing setup. Not supported by the pi harness.
+# existing setup. Supported by all three harnesses (opencode, pi, claude-code);
+# none of them writes to your own harness configuration to do it.
 BENCH_HARNESS_ENDPOINT=
 
 # Path to the pi coding agent directory (used by benchkit/harness/pi.py)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,7 +137,9 @@ The harness runs use **your** opencode / pi configuration and credentials — wh
 run in the editor, you can benchmark. Pick the model with `-m` (any unique part of a
 `provider/model` pair works), or omit it and choose from the list at the start of the run.
 For a server the harness has no entry for, `--endpoint <url>` points it there for that run
-only, without touching your config.
+only, without touching your config. All three harnesses accept it — opencode and claude-code
+through a throwaway config, pi through a copy of your catalogue staged in the run's temp
+directory.
 
 The gap is not cosmetic — on this repo's first such comparison the same model scored 67.4
 through the built-in loop and 77.4 through pi. When you report a number, name the harness it

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,7 +138,7 @@ run in the editor, you can benchmark. Pick the model with `-m` (any unique part 
 `provider/model` pair works), or omit it and choose from the list at the start of the run.
 For a server the harness has no entry for, `--endpoint <url>` points it there for that run
 only, without touching your config. All three harnesses accept it — opencode and claude-code
-through a throwaway config, pi through a copy of your catalogue staged in the run's temp
+through a throwaway config, pi through a throwaway catalogue staged in the run's temp
 directory.
 
 The gap is not cosmetic — on this repo's first such comparison the same model scored 67.4

--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ serve, not a number you quote:
 - **Two workload shapes.** One-shot code generation *and* multi-turn agentic tool calling,
   because they disagree.
 - **Your harness and your models, not ours.** `bench harness models` lists what your
-  opencode or pi install can already reach; pick one and benchmark it. Nothing is written to
-  your editor's configuration.
+  opencode or pi install can already reach; pick one and benchmark it. A model neither knows
+  about is reachable with `--endpoint <url>` on any of the three harnesses. Nothing is
+  written to your editor's configuration either way.
 - **Your harness, not ours.** The same model scores 12 points apart through four different
   tool loops, so the suites also run through the coding agent you actually use (`pi`,
   `opencode`, `claude-code`).

--- a/benchkit/cli.py
+++ b/benchkit/cli.py
@@ -216,7 +216,7 @@ def cmd_harness(args):
         return 0
 
     # --- which model, from the user's own setup --------------------------
-    probe = H.get(args.harness, **_endpoint_kw(args.harness, endpoint))
+    probe = H.get(args.harness, **_endpoint_kw(endpoint))
     entries = [] if endpoint else hmodels.catalogue(probe)
     spec = args.model or os.environ.get("BENCH_HARNESS_MODEL") or ""
     if spec:
@@ -227,7 +227,7 @@ def cmd_harness(args):
         provider, model = hmodels.pick(args.harness, entries)
 
     h = H.get(args.harness, provider=provider, model=model,
-              **_endpoint_kw(args.harness, endpoint))
+              **_endpoint_kw(endpoint))
     tasks = get(args.suite)
     if kind(args.suite) != "agentic":
         raise SystemExit("harness runs need an agentic suite "
@@ -273,8 +273,13 @@ def cmd_harness(args):
     return 0
 
 
-def _endpoint_kw(name, endpoint):
-    """An explicit endpoint is opt-in, and not every harness can take one."""
+def _endpoint_kw(endpoint):
+    """An explicit endpoint is opt-in; all three harnesses accept one.
+
+    Every adapter points its tool at a throwaway config for the run rather than
+    editing the user's — opencode via OPENCODE_CONFIG, claude-code via
+    CLAUDE_CONFIG_DIR, pi via a staged catalogue behind PI_CODING_AGENT_DIR.
+    """
     if not endpoint:
         return {}
     return {"base_url": endpoint}
@@ -391,8 +396,9 @@ def main(argv=None):
     s.add_argument("--provider", help="restrict --model to one provider")
     s.add_argument("--endpoint", default="",
                    help="OpenAI-compatible endpoint to point the harness at for "
-                        "this run instead of using its configured providers "
-                        "(default: BENCH_HARNESS_ENDPOINT; pi does not support it)")
+                        "this run instead of using its configured providers, "
+                        "without touching your harness config "
+                        "(default: BENCH_HARNESS_ENDPOINT)")
     s.add_argument("--suite", default="agentic-hard", choices=list(SUITES))
     s.add_argument("--samples", type=int, default=1)
     s.add_argument("--concurrency", type=int, default=2)

--- a/benchkit/harness/models.py
+++ b/benchkit/harness/models.py
@@ -13,8 +13,10 @@ is being measured:
   answered with the list of real choices instead of a `ProviderModelNotFound`
   error a second into every task.
 - **explicit endpoint** (`--endpoint`): the harness is pointed at an
-  OpenAI-compatible server for this run only. The catalogue does not apply — the
-  model id is whatever that server reports — so the spec is taken literally.
+  OpenAI-compatible server for this run only, through a throwaway config the run
+  owns, so the user's own harness configuration is never written to. Every
+  harness supports this. The catalogue does not apply — the model id is whatever
+  that server reports — so the spec is taken literally.
 """
 import sys
 

--- a/benchkit/harness/pi.py
+++ b/benchkit/harness/pi.py
@@ -182,6 +182,10 @@ class PiHarness(Harness):
         v, err = self._version()
         if err:
             return False, err
+        if self.uses_endpoint:
+            # Nothing to count: an endpoint run does not consult the catalogue,
+            # so reporting it empty would read as a broken pi install.
+            return True, f"pi {v} — endpoint mode ({self.base_url})"
         n = len(self.list_models())
         return True, (f"pi {v} — {n} model(s) in your catalogue"
                       if n else f"pi {v} — no models in your catalogue")
@@ -191,6 +195,10 @@ class PiHarness(Harness):
         if err:
             return False, err
         if not self.model:
+            if self.uses_endpoint:
+                # `harness models` cannot help here: the endpoint defines the id.
+                return False, (f"pi {v}: --endpoint needs --model "
+                               f"<id served by {self.base_url}>")
             return False, (f"pi {v}: no model selected — "
                            f"`bench harness models --harness pi`")
         if self.uses_endpoint:

--- a/benchkit/harness/pi.py
+++ b/benchkit/harness/pi.py
@@ -35,36 +35,73 @@ globally, so the adapter passes `--model <id>` always and `--provider` only when
 the provider really is one pi will accept — the listing's provider column is
 kept for labelling and reporting either way.
 
-There is no explicit-endpoint mode here, unlike the opencode and claude-code
-adapters: pi has no way to take a base URL on the command line, and quietly
-writing a provider into the user's `models.json` would change their editor.
-Adding an endpoint means adding it to pi, once, the normal way.
+### Pointing it at an endpoint pi has never heard of
+
+`--endpoint <url>` benchmarks a server that is not in the user's catalogue —
+a freshly served HuggingFace model, a local vLLM — without touching their pi
+configuration. pi has no base-URL flag, so the adapter does the same thing the
+opencode and claude-code adapters do with `OPENCODE_CONFIG` / `CLAUDE_CONFIG_DIR`:
+it stages a *copy* of the catalogue in the run's temp directory, adds one
+synthetic OpenAI-compatible provider pointing at the endpoint, and hands that
+copy to the subprocess through `PI_CODING_AGENT_DIR`. The user's
+`~/.pi/agent/models.json` is read and never written — copy out, never write back.
+
+```bash
+bench harness run --harness pi --endpoint http://localhost:8001/v1 \
+    -m montimage-dgx-spark
+```
+
+Thinking in endpoint mode is best-effort: the staged provider declares a plain
+OpenAI-compatible server, so a model that needs a particular `compat.thinkingFormat`
+is still better added to pi's own catalogue.
 """
 import json
 import os
 import shutil
 import subprocess
+import urllib.request
 
 from .base import Harness, HarnessResult
 
 THINKING_LEVELS = {False: "off", True: "high"}
+
+#: pi's model catalogue, relative to the agent directory
+CATALOGUE_NAME = "models.json"
+
+#: subdirectory of the run container holding the staged catalogue copy
+STAGED_AGENT_DIR = "pi-agent"
+
+#: where pi looks when neither --agent-dir nor PI_CODING_AGENT_DIR says otherwise
+DEFAULT_AGENT_DIR = "~/.pi/agent"
+
+#: provider id used for the staged catalogue in explicit-endpoint mode
+DEFAULT_ENDPOINT_PROVIDER = "benchkit"
+
+#: conservative limits for a server we know nothing about beyond its URL
+ENDPOINT_CONTEXT_WINDOW = 128000
+ENDPOINT_MAX_TOKENS = 16384
 
 
 class PiHarness(Harness):
     name = "pi"
 
     def __init__(self, provider=None, model=None, base_url=None,
-                 binary="pi", agent_dir=None, extra_args=()):
-        if base_url:
-            raise SystemExit(
-                "the pi harness has no explicit-endpoint mode: pi resolves models "
-                "through its own catalogue. Add the endpoint to pi's models.json "
-                "once, then select it with --model <provider>/<model>.")
-        self.provider = provider
+                 binary="pi", agent_dir=None, api_key=None, extra_args=()):
+        self.base_url = base_url or None
+        self.provider = provider or (DEFAULT_ENDPOINT_PROVIDER if self.base_url else None)
         self.model = model
         self.binary = binary
         self.agent_dir = agent_dir or os.environ.get("PI_CODING_AGENT_DIR")
+        #: the user's own agent directory, resolved once. Read, never written:
+        #: endpoint mode copies out of it and repoints `agent_dir` at the copy.
+        self.source_agent_dir = self.agent_dir or DEFAULT_AGENT_DIR
+        self.api_key = api_key
         self.extra_args = list(extra_args)
+
+    @property
+    def uses_endpoint(self):
+        """True when this run reads a staged catalogue instead of the user's."""
+        return bool(self.base_url)
 
     # --- discovery ------------------------------------------------------
     def _version(self):
@@ -92,7 +129,13 @@ class PiHarness(Harness):
         images`, so the first two whitespace-separated columns are the pair we
         need. Falls back to reading `models.json` directly if the table cannot
         be parsed, because a listing failure must not look like an empty setup.
+
+        In explicit-endpoint mode there is nothing to enumerate: the injected
+        provider exists only for the duration of a run, and the model id is
+        whatever the endpoint serves.
         """
+        if self.uses_endpoint:
+            return []
         path = shutil.which(self.binary)
         if path:
             try:
@@ -111,17 +154,19 @@ class PiHarness(Harness):
                 return entries
         return self._catalogue_models()
 
-    def _catalogue_path(self):
+    def _catalogue_path(self, agent_dir=None):
         return os.path.expanduser(
-            os.path.join(self.agent_dir or "~/.pi/agent", "models.json"))
+            os.path.join(agent_dir or self.agent_dir or DEFAULT_AGENT_DIR,
+                         CATALOGUE_NAME))
 
-    def _catalogue(self):
+    def _catalogue(self, agent_dir=None):
         """(providers, error) read straight from pi's model catalogue file."""
-        path = self._catalogue_path()
+        path = self._catalogue_path(agent_dir)
         if not os.path.exists(path):
             return None, f"no pi model catalogue at {path}"
         try:
-            return json.load(open(path)).get("providers", {}), None
+            with open(path) as f:
+                return json.load(f).get("providers", {}), None
         except Exception as e:  # noqa: BLE001
             return None, f"unreadable {path}: {e}"
 
@@ -147,6 +192,8 @@ class PiHarness(Harness):
         if not self.model:
             return False, (f"pi {v}: no model selected — "
                            f"`bench harness models --harness pi`")
+        if self.uses_endpoint:
+            return self._endpoint_available(v)
         entries = self.list_models()
         if not entries:
             return False, (f"pi {v} lists no models; check `pi --list-models` "
@@ -162,15 +209,88 @@ class PiHarness(Harness):
                            f"have: {', '.join(map(str, pool)) or 'none'}")
         return True, f"pi {v} via {self.model_spec}"
 
+    def _endpoint_available(self, v):
+        """Check the model against the endpoint, not against your catalogue.
+
+        In endpoint mode the catalogue cannot answer the question — the served
+        model is deliberately not in it — so the endpoint's own `/models` is
+        asked instead, exactly as the opencode adapter does.
+        """
+        url = self.base_url.rstrip("/") + "/models"
+        try:
+            with urllib.request.urlopen(url, timeout=10) as r:
+                ids = [m.get("id") for m in json.load(r).get("data", [])]
+        except Exception as e:  # noqa: BLE001
+            return False, f"endpoint {url} unreachable: {e}"
+        if self.model not in ids:
+            return False, (f"model {self.model!r} not served at {self.base_url}; "
+                           f"have: {', '.join(map(str, ids)) or 'none'}")
+        return True, f"pi {v} via {self.base_url} ({self.model})"
+
     def describe(self):
         ok, detail = self.available()
         return dict(harness="pi", provider=self.provider, model=self.model,
-                    model_spec=self.model_spec, source="pi-catalogue",
+                    model_spec=self.model_spec, base_url=self.base_url,
+                    source="endpoint" if self.uses_endpoint else "pi-catalogue",
                     available=ok, detail=detail)
 
     @property
     def model_spec(self):
         return f"{self.provider}/{self.model}" if self.provider else self.model
+
+    # --- workspace ------------------------------------------------------
+    def prepare(self, container):
+        """Endpoint mode: task files in container/work, staged catalogue beside.
+
+        The user's pi configuration is copied out and never written back. We
+        read their catalogue, add one synthetic OpenAI-compatible provider to
+        the *copy*, write the copy into the run's own temp directory, and point
+        `PI_CODING_AGENT_DIR` at it for the subprocess only — the seam `_env()`
+        and `_catalogue_path()` already honour. Staging it in a sibling of the
+        workspace rather than in the workspace itself keeps `models.json` out of
+        the directory that gets read back and scored.
+
+        Without `--endpoint` nothing is staged and nothing is redirected: the
+        run uses the user's own catalogue and credentials, unchanged.
+        """
+        if not self.uses_endpoint:
+            return container
+        workdir = os.path.join(container, "work")
+        os.makedirs(workdir, exist_ok=True)
+        staged = os.path.join(container, STAGED_AGENT_DIR)
+        os.makedirs(staged, exist_ok=True)
+        with open(os.path.join(staged, CATALOGUE_NAME), "w") as f:
+            json.dump(self._staged_catalogue(), f, indent=2)
+        self.agent_dir = staged
+        return workdir
+
+    def _staged_catalogue(self):
+        """The user's providers plus ours — as a new dict, never their file."""
+        providers, _ = self._catalogue(self.source_agent_dir)
+        merged = dict(providers or {})
+        merged[self.provider] = self._endpoint_provider()
+        return {"providers": merged}
+
+    def _endpoint_provider(self):
+        """One synthetic OpenAI-compatible provider aimed at `--endpoint`."""
+        return {
+            "name": f"benchkit ({self.base_url})",
+            "baseUrl": self.base_url,
+            "api": "openai-completions",
+            # pi wants a key field; an open local server ignores the value.
+            "apiKey": self.api_key or "not-needed",
+            "compat": {"supportsReasoningEffort": False,
+                       "maxTokensField": "max_tokens"},
+            "models": [{
+                "id": self.model,
+                "name": self.model,
+                "reasoning": True,
+                "input": ["text"],
+                "contextWindow": ENDPOINT_CONTEXT_WINDOW,
+                "maxTokens": ENDPOINT_MAX_TOKENS,
+                "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
+            }],
+        }
 
     # --- execution ------------------------------------------------------
     def _argv(self, prompt, thinking):

--- a/benchkit/harness/pi.py
+++ b/benchkit/harness/pi.py
@@ -41,10 +41,11 @@ kept for labelling and reporting either way.
 a freshly served HuggingFace model, a local vLLM — without touching their pi
 configuration. pi has no base-URL flag, so the adapter does the same thing the
 opencode and claude-code adapters do with `OPENCODE_CONFIG` / `CLAUDE_CONFIG_DIR`:
-it stages a *copy* of the catalogue in the run's temp directory, adds one
-synthetic OpenAI-compatible provider pointing at the endpoint, and hands that
-copy to the subprocess through `PI_CODING_AGENT_DIR`. The user's
-`~/.pi/agent/models.json` is read and never written — copy out, never write back.
+it stages a throwaway catalogue in the run's temp directory holding one
+synthetic OpenAI-compatible provider pointed at the endpoint, and hands it to
+the subprocess through `PI_CODING_AGENT_DIR`. The user's
+`~/.pi/agent/models.json` is never written, and in this mode never even read —
+their credentials stay where they are.
 
 ```bash
 bench harness run --harness pi --endpoint http://localhost:8001/v1 \
@@ -91,10 +92,9 @@ class PiHarness(Harness):
         self.provider = provider or (DEFAULT_ENDPOINT_PROVIDER if self.base_url else None)
         self.model = model
         self.binary = binary
+        #: the user's own agent directory. Read for a normal run, and in
+        #: endpoint mode not even that — it is never opened for writing.
         self.agent_dir = agent_dir or os.environ.get("PI_CODING_AGENT_DIR")
-        #: the user's own agent directory, resolved once. Read, never written:
-        #: endpoint mode copies out of it and repoints `agent_dir` at the copy.
-        self.source_agent_dir = self.agent_dir or DEFAULT_AGENT_DIR
         self.api_key = api_key
         self.extra_args = list(extra_args)
 
@@ -115,10 +115,11 @@ class PiHarness(Harness):
         except Exception as e:  # noqa: BLE001
             return None, f"{self.binary} --version failed: {e}"
 
-    def _env(self):
+    def _env(self, agent_dir=None):
         env = dict(os.environ)
-        if self.agent_dir:
-            env["PI_CODING_AGENT_DIR"] = self.agent_dir
+        agent_dir = agent_dir or self.agent_dir
+        if agent_dir:
+            env["PI_CODING_AGENT_DIR"] = agent_dir
         env["PI_OFFLINE"] = "1"     # no update checks mid-benchmark
         return env
 
@@ -242,13 +243,17 @@ class PiHarness(Harness):
     def prepare(self, container):
         """Endpoint mode: task files in container/work, staged catalogue beside.
 
-        The user's pi configuration is copied out and never written back. We
-        read their catalogue, add one synthetic OpenAI-compatible provider to
-        the *copy*, write the copy into the run's own temp directory, and point
-        `PI_CODING_AGENT_DIR` at it for the subprocess only — the seam `_env()`
-        and `_catalogue_path()` already honour. Staging it in a sibling of the
-        workspace rather than in the workspace itself keeps `models.json` out of
-        the directory that gets read back and scored.
+        The staged catalogue is written into the run's own temp directory and
+        handed to the subprocess through `PI_CODING_AGENT_DIR` — the seam
+        `_env()` and `_catalogue_path()` already honour. Staging it in a sibling
+        of the workspace rather than in the workspace itself keeps `models.json`
+        out of the directory that gets read back and scored.
+
+        Its path is derived from `container`, never remembered on `self`: a
+        single harness instance serves every task, and the runner drives those
+        tasks on a thread pool, so an instance field would let one task's
+        subprocess be pointed at another task's directory after that one had
+        been cleaned up.
 
         Without `--endpoint` nothing is staged and nothing is redirected: the
         run uses the user's own catalogue and credentials, unchanged.
@@ -261,15 +266,24 @@ class PiHarness(Harness):
         os.makedirs(staged, exist_ok=True)
         with open(os.path.join(staged, CATALOGUE_NAME), "w") as f:
             json.dump(self._staged_catalogue(), f, indent=2)
-        self.agent_dir = staged
         return workdir
 
+    def _staged_dir(self, workdir):
+        """Where `prepare()` put this task's catalogue, from its workdir alone."""
+        return os.path.join(os.path.dirname(workdir), STAGED_AGENT_DIR)
+
     def _staged_catalogue(self):
-        """The user's providers plus ours — as a new dict, never their file."""
-        providers, _ = self._catalogue(self.source_agent_dir)
-        merged = dict(providers or {})
-        merged[self.provider] = self._endpoint_provider()
-        return {"providers": merged}
+        """A catalogue holding the endpoint provider and nothing else.
+
+        The user's own providers are deliberately *not* copied in. Nothing in an
+        endpoint run can address them — `--model`/`--provider` both name the
+        injected one — so copying them would only duplicate their `apiKey`
+        values into a temp directory for no benefit, and would leave a route by
+        which a run could reach a model other than the one being benchmarked.
+        Their file is never opened here at all: copy out, never write back, and
+        in this mode not even copy.
+        """
+        return {"providers": {self.provider: self._endpoint_provider()}}
 
     def _endpoint_provider(self):
         """One synthetic OpenAI-compatible provider aimed at `--endpoint`."""
@@ -293,11 +307,12 @@ class PiHarness(Harness):
         }
 
     # --- execution ------------------------------------------------------
-    def _argv(self, prompt, thinking):
+    def _argv(self, prompt, thinking, agent_dir=None):
         return [
             self.binary, "-p", prompt,
             # Only providers pi itself will accept; see the module docstring.
-            *(["--provider", self.provider] if self._provider_addressable() else []),
+            *(["--provider", self.provider]
+              if self._provider_addressable(agent_dir) else []),
             "--model", self.model,
             "--thinking", THINKING_LEVELS[bool(thinking)],
             "--mode", "json",
@@ -307,17 +322,21 @@ class PiHarness(Harness):
             "--approve",            # trust the temp workspace, do not block on a prompt
         ] + self.extra_args
 
-    def _provider_addressable(self):
+    def _provider_addressable(self, agent_dir=None):
         """Is `--provider <name>` a thing pi will accept, or listing-only?"""
         if not self.provider:
             return False
-        provs, err = self._catalogue()
+        provs, err = self._catalogue(agent_dir)
         return bool(not err and self.provider in provs)
 
     def run(self, workdir, prompt, timeout=900, thinking=False):
-        env = self._env()
+        # Endpoint mode reads the catalogue this task staged, found from the
+        # workdir rather than from shared state — see prepare().
+        agent_dir = self._staged_dir(workdir) if self.uses_endpoint else None
+        env = self._env(agent_dir)
         try:
-            p = subprocess.run(self._argv(prompt, thinking), cwd=workdir, env=env,
+            p = subprocess.run(self._argv(prompt, thinking, agent_dir),
+                               cwd=workdir, env=env,
                                capture_output=True, text=True, timeout=timeout,
                                # pi blocks forever on an inherited stdin it can never
                                # read; every task then times out with zero turns.

--- a/docs/HARNESSES.md
+++ b/docs/HARNESSES.md
@@ -48,7 +48,7 @@ accept it, and none of them writes to your own configuration to do it:
 |---|---|
 | `opencode` | a throwaway provider config next to the temp workspace, handed over as `OPENCODE_CONFIG` |
 | `claude-code` | `ANTHROPIC_BASE_URL` plus a throwaway `CLAUDE_CONFIG_DIR` |
-| `pi` | a **copy** of your catalogue in the run's temp dir with one extra provider, handed over as `PI_CODING_AGENT_DIR` |
+| `pi` | a throwaway catalogue in the run's temp dir holding one extra provider, handed over as `PI_CODING_AGENT_DIR` |
 
 In this mode the harness catalogue does not apply, so `--model` must name the id that
 endpoint serves — it is checked against the endpoint's `/models` before the run starts:
@@ -122,15 +122,18 @@ provider/model pairs it prints; `available()` then re-checks the choice against
 ### Pointing it at an endpoint it has never heard of
 
 pi takes no base URL on the command line, so `--endpoint` is served the same way the other
-two adapters serve it: with a throwaway config the run owns. `prepare()` reads
-`~/.pi/agent/models.json` (or `PI_CODING_AGENT_DIR`), **copies** it into the run's temp
-directory, adds one synthetic `benchkit` provider of `api: openai-completions` pointed at
-the endpoint, and exports `PI_CODING_AGENT_DIR` for the subprocess only.
+two adapters serve it: with a throwaway config the run owns. `prepare()` writes a catalogue
+into the run's temp directory holding a single synthetic `benchkit` provider of
+`api: openai-completions` pointed at the endpoint, and exports `PI_CODING_AGENT_DIR` for the
+subprocess only.
 
-Your `models.json` is opened for reading and never for writing — copy out, never write
-back — and a run without `--endpoint` stages nothing at all and uses your own catalogue and
-credentials unchanged. The staged copy lives in a *sibling* of the workspace, so it never
-appears in the directory that gets read back and scored.
+Your `~/.pi/agent/models.json` is never written, and in endpoint mode never even read: your
+own providers are deliberately left out of the staged catalogue, so no `apiKey` of yours is
+duplicated into a temp directory and nothing in the run can reach a model other than the one
+being benchmarked. A run *without* `--endpoint` stages nothing at all and uses your own
+catalogue and credentials unchanged. The staged catalogue lives in a *sibling* of the
+workspace, so it never appears in the directory that gets read back and scored, and its path
+comes from that task's own temp dir — tasks run on a thread pool and must not share it.
 
 ```bash
 ./bench harness run --harness pi --endpoint http://localhost:8001/v1 -m montimage-dgx-spark

--- a/docs/HARNESSES.md
+++ b/docs/HARNESSES.md
@@ -48,7 +48,7 @@ accept it, and none of them writes to your own configuration to do it:
 |---|---|
 | `opencode` | a throwaway provider config next to the temp workspace, handed over as `OPENCODE_CONFIG` |
 | `claude-code` | `ANTHROPIC_BASE_URL` plus a throwaway `CLAUDE_CONFIG_DIR` |
-| `pi` | a throwaway catalogue in the run's temp dir holding one extra provider, handed over as `PI_CODING_AGENT_DIR` |
+| `pi` | a throwaway catalogue in the run's temp dir holding one synthetic provider and nothing else, handed over as `PI_CODING_AGENT_DIR` |
 
 In this mode the harness catalogue does not apply, so `--model` must name the id that
 endpoint serves — it is checked against the endpoint's `/models` before the run starts:

--- a/docs/HARNESSES.md
+++ b/docs/HARNESSES.md
@@ -40,21 +40,25 @@ never write to it. The one exception is `--endpoint`.
 
 ### `--endpoint`: a server the harness does not know about
 
-For a local vLLM or llama.cpp that is not in your opencode config, `--endpoint
-http://host:port/v1` points the harness at it **for this run only** — opencode gets a
-throwaway provider config next to the temp workspace, Claude Code gets `ANTHROPIC_BASE_URL`
-and a throwaway config home. Your real config is untouched either way. In this mode the
-harness catalogue does not apply, so `--model` must name the id that endpoint serves:
+For a local vLLM or llama.cpp that is not in your harness config, `--endpoint
+http://host:port/v1` points the harness at it **for this run only**. All three harnesses
+accept it, and none of them writes to your own configuration to do it:
+
+| Harness | How the endpoint is injected |
+|---|---|
+| `opencode` | a throwaway provider config next to the temp workspace, handed over as `OPENCODE_CONFIG` |
+| `claude-code` | `ANTHROPIC_BASE_URL` plus a throwaway `CLAUDE_CONFIG_DIR` |
+| `pi` | a **copy** of your catalogue in the run's temp dir with one extra provider, handed over as `PI_CODING_AGENT_DIR` |
+
+In this mode the harness catalogue does not apply, so `--model` must name the id that
+endpoint serves — it is checked against the endpoint's `/models` before the run starts:
 
 ```bash
 ./bench harness run --harness opencode --endpoint http://localhost:8001/v1 \
     -m montimage-dgx-spark --suite agentic-hard
+./bench harness run --harness pi --endpoint http://localhost:8001/v1 \
+    -m montimage-dgx-spark --suite agentic-hard
 ```
-
-pi has no `--endpoint` mode and says so rather than pretending: it resolves models only
-through its own catalogue, and silently writing a provider into `~/.pi/agent/models.json`
-would change how the user's editor behaves. Add the endpoint to pi once, the normal way, and
-it shows up in `bench harness models` like everything else.
 
 The label and result filename carry the model, not just the harness — `opencode
 ollama-qwen3-coder-latest think-OFF` — because benchmarking two models through one harness is
@@ -114,6 +118,27 @@ provider/model pairs it prints; `available()` then re-checks the choice against
 ./bench harness run --harness pi -m local-dgx/montimage-dgx-spark
 ./bench harness run --harness pi --provider local-dgx -m montimage-dgx-spark   # equivalent
 ```
+
+### Pointing it at an endpoint it has never heard of
+
+pi takes no base URL on the command line, so `--endpoint` is served the same way the other
+two adapters serve it: with a throwaway config the run owns. `prepare()` reads
+`~/.pi/agent/models.json` (or `PI_CODING_AGENT_DIR`), **copies** it into the run's temp
+directory, adds one synthetic `benchkit` provider of `api: openai-completions` pointed at
+the endpoint, and exports `PI_CODING_AGENT_DIR` for the subprocess only.
+
+Your `models.json` is opened for reading and never for writing — copy out, never write
+back — and a run without `--endpoint` stages nothing at all and uses your own catalogue and
+credentials unchanged. The staged copy lives in a *sibling* of the workspace, so it never
+appears in the directory that gets read back and scored.
+
+```bash
+./bench harness run --harness pi --endpoint http://localhost:8001/v1 -m montimage-dgx-spark
+```
+
+One caveat: the staged provider describes a plain OpenAI-compatible server, so thinking is
+best-effort. A model that needs a particular `compat.thinkingFormat` (the local Qwen wants
+`qwen-chat-template`) is still better added to pi's own catalogue and selected with `-m`.
 
 ### Thinking
 

--- a/tests/test_harness_models.py
+++ b/tests/test_harness_models.py
@@ -108,7 +108,7 @@ class TestHarnessDefaults(unittest.TestCase):
                 self.assertIsNone(get(name).model)
 
     def test_no_endpoint_unless_asked(self):
-        for name in ("opencode", "claude-code"):
+        for name in HARNESSES:
             with self.subTest(harness=name):
                 self.assertIsNone(get(name).base_url)
                 self.assertFalse(get(name).uses_endpoint)
@@ -120,10 +120,21 @@ class TestHarnessDefaults(unittest.TestCase):
                 if ok:
                     self.fail(f"{name} reports available with no model: {detail}")
 
-    def test_pi_rejects_an_endpoint_rather_than_ignoring_it(self):
-        with self.assertRaises(SystemExit) as cm:
-            get("pi", base_url="http://localhost:8001/v1")
-        self.assertIn("models.json", str(cm.exception))
+    def test_pi_accepts_an_endpoint(self):
+        """pi used to refuse one outright; it now stages a catalogue instead."""
+        h = get("pi", model="m", base_url="http://localhost:8001/v1")
+        self.assertTrue(h.uses_endpoint)
+        self.assertEqual(h.base_url, "http://localhost:8001/v1")
+        self.assertEqual(h.provider, "benchkit")
+        self.assertEqual(h.describe()["source"], "endpoint")
+
+    def test_every_harness_takes_the_same_endpoint_kwarg(self):
+        """--endpoint is one contract, not three: cli.py passes it blindly."""
+        for name in HARNESSES:
+            with self.subTest(harness=name):
+                h = get(name, model="m", base_url="http://x/v1")
+                self.assertTrue(h.uses_endpoint)
+                self.assertEqual(h.describe()["source"], "endpoint")
 
     def test_opencode_injects_config_only_for_an_endpoint(self):
         h = get("opencode", provider="ollama", model="m")

--- a/tests/test_harness_models.py
+++ b/tests/test_harness_models.py
@@ -99,6 +99,17 @@ class TestCatalogue(unittest.TestCase):
         self.assertEqual(models.spec("ollama", "m"), "ollama/m")
 
 
+def _offline_describe(h):
+    """describe() without the reachability probe it normally runs.
+
+    `available()` calls the endpoint, and a unit suite must not care what
+    happens to be serving on the machine running it — nor pay a DNS timeout for
+    a hostname invented by the test.
+    """
+    h.available = lambda: (True, "stubbed")
+    return h.describe()
+
+
 class TestHarnessDefaults(unittest.TestCase):
     """No harness may default to one machine's model or endpoint."""
 
@@ -126,7 +137,7 @@ class TestHarnessDefaults(unittest.TestCase):
         self.assertTrue(h.uses_endpoint)
         self.assertEqual(h.base_url, "http://localhost:8001/v1")
         self.assertEqual(h.provider, "benchkit")
-        self.assertEqual(h.describe()["source"], "endpoint")
+        self.assertEqual(_offline_describe(h)["source"], "endpoint")
 
     def test_every_harness_takes_the_same_endpoint_kwarg(self):
         """--endpoint is one contract, not three: cli.py passes it blindly."""
@@ -134,7 +145,7 @@ class TestHarnessDefaults(unittest.TestCase):
             with self.subTest(harness=name):
                 h = get(name, model="m", base_url="http://x/v1")
                 self.assertTrue(h.uses_endpoint)
-                self.assertEqual(h.describe()["source"], "endpoint")
+                self.assertEqual(_offline_describe(h)["source"], "endpoint")
 
     def test_opencode_injects_config_only_for_an_endpoint(self):
         h = get("opencode", provider="ollama", model="m")

--- a/tests/test_pi_endpoint.py
+++ b/tests/test_pi_endpoint.py
@@ -1,0 +1,230 @@
+"""Tests for the pi harness's explicit-endpoint mode.
+
+The promise being tested is narrow and load-bearing: `--endpoint` must let pi
+benchmark a server that is not in the user's catalogue, and it must do that
+*without* the run ever writing to the user's own pi configuration. Copy out,
+never write back — so the tests below check both halves, and the non-mutation
+half is checked byte-for-byte rather than by inspection.
+"""
+import json
+import os
+import sys
+import tempfile
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from benchkit.harness import get  # noqa: E402
+from benchkit.harness.pi import (  # noqa: E402
+    CATALOGUE_NAME,
+    DEFAULT_ENDPOINT_PROVIDER,
+    STAGED_AGENT_DIR,
+)
+
+ENDPOINT = "http://localhost:8001/v1"
+
+#: a stand-in for ~/.pi/agent/models.json, with the user's own provider in it
+USER_CATALOGUE = {
+    "providers": {
+        "local-dgx": {
+            "baseUrl": "http://localhost:9999/v1",
+            "api": "openai-completions",
+            "apiKey": "secret-of-the-user",
+            "models": [{"id": "montimage-dgx-spark", "name": "DGX"}],
+        }
+    }
+}
+
+
+class PiEndpointCase(unittest.TestCase):
+    """A fake pi agent directory plus a fresh run container for each test."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.agent_dir = os.path.join(self.tmp.name, "pi-agent-home")
+        os.makedirs(self.agent_dir)
+        self.catalogue = os.path.join(self.agent_dir, CATALOGUE_NAME)
+        with open(self.catalogue, "w") as f:
+            json.dump(USER_CATALOGUE, f, indent=2)
+        with open(self.catalogue, "rb") as f:
+            self.before = f.read()
+        self.container = os.path.join(self.tmp.name, "container")
+        os.makedirs(self.container)
+
+    def harness(self, **kw):
+        kw.setdefault("agent_dir", self.agent_dir)
+        return get("pi", **kw)
+
+    def staged(self):
+        return os.path.join(self.container, STAGED_AGENT_DIR, CATALOGUE_NAME)
+
+    def assert_user_config_untouched(self):
+        with open(self.catalogue, "rb") as f:
+            self.assertEqual(f.read(), self.before,
+                             "the user's pi catalogue was modified by the run")
+
+    def read_json(self, path):
+        with open(path) as f:
+            return json.load(f)
+
+
+class TestEndpointStaging(PiEndpointCase):
+    def test_prepare_writes_the_endpoint_provider_into_a_copy(self):
+        h = self.harness(model="served-model", base_url=ENDPOINT)
+        workdir = h.prepare(self.container)
+
+        catalogue = self.read_json(self.staged())
+        provider = catalogue["providers"][DEFAULT_ENDPOINT_PROVIDER]
+        self.assertEqual(provider["baseUrl"], ENDPOINT)
+        self.assertEqual(provider["api"], "openai-completions")
+        self.assertEqual([m["id"] for m in provider["models"]], ["served-model"])
+        # the workspace that gets scored must not contain pi's plumbing
+        self.assertTrue(workdir.startswith(self.container))
+        self.assertNotEqual(os.path.dirname(self.staged()), workdir)
+
+    def test_the_users_own_providers_survive_in_the_copy(self):
+        """Copying, not replacing: their providers stay reachable in the run."""
+        h = self.harness(model="served-model", base_url=ENDPOINT)
+        h.prepare(self.container)
+        providers = self.read_json(self.staged())["providers"]
+        self.assertIn("local-dgx", providers)
+        self.assertIn(DEFAULT_ENDPOINT_PROVIDER, providers)
+
+    def test_the_users_catalogue_is_never_written(self):
+        """The whole reason pi refused an endpoint before: prove it is safe."""
+        h = self.harness(model="served-model", base_url=ENDPOINT)
+        h.prepare(self.container)
+        self.assert_user_config_untouched()
+
+    def test_the_subprocess_is_pointed_at_the_copy(self):
+        h = self.harness(model="served-model", base_url=ENDPOINT)
+        h.prepare(self.container)
+        env = h._env()
+        self.assertEqual(env["PI_CODING_AGENT_DIR"],
+                         os.path.join(self.container, STAGED_AGENT_DIR))
+        self.assertNotEqual(env["PI_CODING_AGENT_DIR"], self.agent_dir)
+
+    def test_the_injected_provider_is_addressable(self):
+        """`--provider benchkit` is only passed if pi would accept it."""
+        h = self.harness(model="served-model", base_url=ENDPOINT)
+        h.prepare(self.container)
+        self.assertTrue(h._provider_addressable())
+        argv = h._argv("do the thing", thinking=False)
+        self.assertIn("--provider", argv)
+        self.assertEqual(argv[argv.index("--provider") + 1],
+                         DEFAULT_ENDPOINT_PROVIDER)
+        self.assertEqual(argv[argv.index("--model") + 1], "served-model")
+
+    def test_a_missing_user_catalogue_is_not_an_error(self):
+        """Endpoint mode must work on a machine with no pi config at all."""
+        empty = os.path.join(self.tmp.name, "nothing-here")
+        os.makedirs(empty)
+        h = get("pi", model="served-model", base_url=ENDPOINT, agent_dir=empty)
+        h.prepare(self.container)
+        providers = self.read_json(self.staged())["providers"]
+        self.assertEqual(list(providers), [DEFAULT_ENDPOINT_PROVIDER])
+        self.assertFalse(os.path.exists(os.path.join(empty, CATALOGUE_NAME)))
+
+    def test_an_explicit_api_key_reaches_the_staged_provider(self):
+        h = self.harness(model="served-model", base_url=ENDPOINT, api_key="k")
+        h.prepare(self.container)
+        providers = self.read_json(self.staged())["providers"]
+        self.assertEqual(providers[DEFAULT_ENDPOINT_PROVIDER]["apiKey"], "k")
+
+
+class TestWithoutAnEndpoint(PiEndpointCase):
+    """No --endpoint means nothing is staged and nothing is redirected."""
+
+    def test_prepare_stages_nothing(self):
+        h = self.harness(provider="local-dgx", model="montimage-dgx-spark")
+        workdir = h.prepare(self.container)
+        self.assertEqual(workdir, self.container)
+        self.assertFalse(os.path.exists(
+            os.path.join(self.container, STAGED_AGENT_DIR)))
+        self.assert_user_config_untouched()
+
+    def test_the_users_own_agent_dir_is_still_used(self):
+        h = self.harness(provider="local-dgx", model="montimage-dgx-spark")
+        h.prepare(self.container)
+        self.assertEqual(h.agent_dir, self.agent_dir)
+        self.assertEqual(h._env()["PI_CODING_AGENT_DIR"], self.agent_dir)
+        self.assertEqual(h._catalogue_path(), self.catalogue)
+
+    def test_the_users_catalogue_still_resolves_the_model(self):
+        h = self.harness(provider="local-dgx", model="montimage-dgx-spark")
+        self.assertEqual(h._catalogue_models(),
+                         [("local-dgx", "montimage-dgx-spark")])
+        self.assertFalse(h.uses_endpoint)
+        self.assertIsNone(h.base_url)
+
+
+class _ModelsHandler(BaseHTTPRequestHandler):
+    """The one route `available()` needs: an OpenAI-compatible /v1/models."""
+
+    served = ["served-model"]
+
+    def do_GET(self):  # noqa: N802 — BaseHTTPRequestHandler's name
+        body = json.dumps({"data": [{"id": i} for i in self.served]}).encode()
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *a):  # keep the test output clean
+        pass
+
+
+class TestEndpointAvailability(PiEndpointCase):
+    """In endpoint mode the endpoint answers, not the catalogue.
+
+    Backed by a stub server rather than a real one: the point is the branch
+    taken, and a benchmark's unit tests must not depend on what happens to be
+    serving on this machine.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.server = HTTPServer(("127.0.0.1", 0), _ModelsHandler)
+        threading.Thread(target=self.server.serve_forever, daemon=True).start()
+        self.addCleanup(self.server.server_close)
+        self.addCleanup(self.server.shutdown)
+        self.url = f"http://127.0.0.1:{self.server.server_port}/v1"
+
+    def test_a_served_model_is_accepted(self):
+        h = self.harness(model="served-model", base_url=self.url)
+        ok, detail = h.available()
+        self.assertTrue(ok, detail)
+        self.assertIn(self.url, detail)
+
+    def test_a_model_the_endpoint_does_not_serve_is_named(self):
+        h = self.harness(model="not-there", base_url=self.url)
+        ok, detail = h.available()
+        self.assertFalse(ok)
+        self.assertIn("not-there", detail)
+        self.assertIn("served-model", detail)
+
+    def test_the_catalogue_is_not_consulted_in_endpoint_mode(self):
+        """`local-dgx/montimage-dgx-spark` is in the fixture and irrelevant here."""
+        h = self.harness(model="montimage-dgx-spark", base_url=self.url)
+        ok, detail = h.available()
+        self.assertFalse(ok, "the user's catalogue must not vouch for an endpoint")
+        self.assertIn("not served at", detail)
+
+    def test_an_unreachable_endpoint_says_so(self):
+        h = self.harness(model="served-model", base_url="http://127.0.0.1:1/v1")
+        ok, detail = h.available()
+        self.assertFalse(ok)
+        self.assertIn("unreachable", detail)
+
+    def test_endpoint_mode_enumerates_nothing(self):
+        """The injected provider exists for one run; there is no list to show."""
+        h = self.harness(model="served-model", base_url=self.url)
+        self.assertEqual(h.list_models(), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pi_endpoint.py
+++ b/tests/test_pi_endpoint.py
@@ -85,13 +85,36 @@ class TestEndpointStaging(PiEndpointCase):
         self.assertTrue(workdir.startswith(self.container))
         self.assertNotEqual(os.path.dirname(self.staged()), workdir)
 
-    def test_the_users_own_providers_survive_in_the_copy(self):
-        """Copying, not replacing: their providers stay reachable in the run."""
+    def test_no_user_credentials_are_copied_into_the_run(self):
+        """Only the injected provider is staged; their apiKeys stay put."""
         h = self.harness(model="served-model", base_url=ENDPOINT)
         h.prepare(self.container)
-        providers = self.read_json(self.staged())["providers"]
-        self.assertIn("local-dgx", providers)
-        self.assertIn(DEFAULT_ENDPOINT_PROVIDER, providers)
+        with open(self.staged()) as f:
+            body = f.read()
+        self.assertNotIn("secret-of-the-user", body)
+        self.assertEqual(list(json.loads(body)["providers"]),
+                         [DEFAULT_ENDPOINT_PROVIDER])
+
+    def test_repeated_prepare_does_not_compound_or_share_state(self):
+        """One instance serves every task, and the runner threads them."""
+        h = self.harness(model="served-model", base_url=ENDPOINT)
+        first = h.prepare(self.container)
+        second_container = os.path.join(self.tmp.name, "container-2")
+        os.makedirs(second_container)
+        second = h.prepare(second_container)
+
+        self.assertNotEqual(first, second)
+        staged_2 = os.path.join(second_container, STAGED_AGENT_DIR, CATALOGUE_NAME)
+        self.assertEqual(self.read_json(self.staged()),
+                         self.read_json(staged_2))
+        # each task's subprocess must be pointed at its *own* staged dir, not
+        # at whichever one prepare() ran last
+        self.assertEqual(h._env(h._staged_dir(first))["PI_CODING_AGENT_DIR"],
+                         os.path.join(self.container, STAGED_AGENT_DIR))
+        self.assertEqual(h._env(h._staged_dir(second))["PI_CODING_AGENT_DIR"],
+                         os.path.join(second_container, STAGED_AGENT_DIR))
+        self.assertEqual(h.agent_dir, self.agent_dir)
+        self.assert_user_config_untouched()
 
     def test_the_users_catalogue_is_never_written(self):
         """The whole reason pi refused an endpoint before: prove it is safe."""
@@ -99,10 +122,10 @@ class TestEndpointStaging(PiEndpointCase):
         h.prepare(self.container)
         self.assert_user_config_untouched()
 
-    def test_the_subprocess_is_pointed_at_the_copy(self):
+    def test_the_subprocess_is_pointed_at_the_staged_catalogue(self):
         h = self.harness(model="served-model", base_url=ENDPOINT)
-        h.prepare(self.container)
-        env = h._env()
+        workdir = h.prepare(self.container)
+        env = h._env(h._staged_dir(workdir))
         self.assertEqual(env["PI_CODING_AGENT_DIR"],
                          os.path.join(self.container, STAGED_AGENT_DIR))
         self.assertNotEqual(env["PI_CODING_AGENT_DIR"], self.agent_dir)
@@ -110,9 +133,10 @@ class TestEndpointStaging(PiEndpointCase):
     def test_the_injected_provider_is_addressable(self):
         """`--provider benchkit` is only passed if pi would accept it."""
         h = self.harness(model="served-model", base_url=ENDPOINT)
-        h.prepare(self.container)
-        self.assertTrue(h._provider_addressable())
-        argv = h._argv("do the thing", thinking=False)
+        workdir = h.prepare(self.container)
+        staged = h._staged_dir(workdir)
+        self.assertTrue(h._provider_addressable(staged))
+        argv = h._argv("do the thing", thinking=False, agent_dir=staged)
         self.assertIn("--provider", argv)
         self.assertEqual(argv[argv.index("--provider") + 1],
                          DEFAULT_ENDPOINT_PROVIDER)
@@ -127,6 +151,14 @@ class TestEndpointStaging(PiEndpointCase):
         providers = self.read_json(self.staged())["providers"]
         self.assertEqual(list(providers), [DEFAULT_ENDPOINT_PROVIDER])
         self.assertFalse(os.path.exists(os.path.join(empty, CATALOGUE_NAME)))
+
+    def test_nothing_is_created_in_the_users_agent_dir(self):
+        """Not one new file: the run has no business writing there at all."""
+        before = sorted(os.listdir(self.agent_dir))
+        h = self.harness(model="served-model", base_url=ENDPOINT)
+        h.prepare(self.container)
+        self.assertEqual(sorted(os.listdir(self.agent_dir)), before)
+        self.assert_user_config_untouched()
 
     def test_an_explicit_api_key_reaches_the_staged_provider(self):
         h = self.harness(model="served-model", base_url=ENDPOINT, api_key="k")


### PR DESCRIPTION
## Summary

`bench harness run --harness pi --endpoint <url> -m <model>` now works. It was
refused outright before, which left goal 1 of this repo — benchmark a fresh
HuggingFace model through *all three* paths — reachable through benchkit and
opencode but not through pi.

## Approach

The old refusal rested on a correct premise and a wrong conclusion: a benchmark
must not rewrite `~/.pi/agent/models.json`, therefore pi cannot take an endpoint.
Both sibling adapters already disprove the "therefore" — opencode points the tool
at a throwaway config with `OPENCODE_CONFIG`, claude-code with `CLAUDE_CONFIG_DIR`
— and pi has the identical seam already wired through `PI_CODING_AGENT_DIR`.

`PiHarness.prepare()` now writes a throwaway catalogue into the run's own temp
directory holding one synthetic `openai-completions` provider aimed at the
endpoint, and hands it to the subprocess through `PI_CODING_AGENT_DIR`. Two
properties are load-bearing and both are tested:

- **The user's pi configuration is never written**, and in endpoint mode never
  even read. Their own providers are deliberately left out of the staged
  catalogue, so no `apiKey` of theirs is duplicated into a temp dir and nothing
  in the run can reach a model other than the one being benchmarked.
- **Nothing is remembered on the harness instance.** One instance serves every
  task and the runner drives tasks on a thread pool, so the staged path is
  derived from each task's own workdir. An instance field would let one task's
  subprocess be pointed at another task's directory after `run_task` had
  already deleted it.

`available()` asks the endpoint's `/models` instead of the catalogue, the way
opencode already does, so a bad `--model` is reported before the run rather than
as a provider error a second into every task. A run *without* `--endpoint` stages
nothing, redirects nothing, and is byte-for-byte the behavior it was.

## Decision Record

**Root cause** — not a missing capability but a deliberate refusal:
`PiHarness.__init__` raised `SystemExit` whenever `base_url` was set
(`benchkit/harness/pi.py:58-62`), on the correct premise that a benchmark must
not rewrite the user's editor config.

**Options considered**

| # | Option | Verdict |
|---|---|---|
| 1 | Temp catalogue in `PiHarness` only | Rejected — ships the capability but leaves four documents asserting the opposite, failing AC3 |
| 2 | Endpoint mode **plus** a consistent three-harness contract and docs | **Selected** |
| 3 | Extract a shared endpoint-config mixin across all three adapters | Rejected — refactors two working adapters with published benchmark numbers behind them to add one capability, and overlaps the dedicated refactor issues #31 and #34 |

**Selected option 2**: stage a throwaway catalogue behind the existing
`PI_CODING_AGENT_DIR` seam, make `_endpoint_kw` and the three adapters agree on
one `--endpoint` contract, and correct every doc that said pi could not take one.

**Residual risk** — in endpoint mode the model cannot be validated against the
user's catalogue, so a wrong `--model` would surface at run time; mitigated by
probing the endpoint's `/models` in `available()`. Thinking is best-effort: the
staged provider describes a plain OpenAI-compatible server, so a model needing a
particular `compat.thinkingFormat` is still better added to pi's own catalogue.
This is stated in the adapter docstring and in `docs/HARNESSES.md`.

Note on the repo hard rules: `tests/test_harness_models.py` was edited to replace
the test that pinned the refusal. That is a **harness unit test**, not a benchmark
task's `tests`/`asserts`/`check` — no task, oracle or predicate was touched, and
`results/` is untouched.

## Changes

| File | What |
|---|---|
| `benchkit/harness/pi.py` | Endpoint mode: `uses_endpoint`, staged catalogue in `prepare()`, `_staged_dir()`/`_staged_catalogue()`/`_endpoint_provider()`, endpoint-aware `available()`/`probe()`/`describe()`/`list_models()`, rewritten docstring |
| `benchkit/cli.py` | `_endpoint_kw` drops its per-harness special case; `--endpoint` help no longer says pi refuses it |
| `benchkit/harness/models.py` | Docstring: every harness supports the explicit-endpoint mode |
| `tests/test_pi_endpoint.py` | **New** — 17 tests over staging, non-mutation, re-entrancy, and endpoint availability |
| `tests/test_harness_models.py` | Refusal test replaced with acceptance + a uniform three-harness endpoint contract test; `test_no_endpoint_unless_asked` extended to pi |
| `docs/HARNESSES.md` | Per-harness endpoint table and a pi endpoint section; the "pi has no `--endpoint` mode" paragraph is gone |
| `README.md`, `AGENTS.md`, `.env.example` | Same correction |

## Test Results

| Check | Result |
|---|---|
| `tests/test_pi_endpoint.py` | 17 passed (new) |
| `tests/test_harness_models.py` | 20 passed |
| `tests/test_compare_dispatch.py`, `tests/test_config_files.py` | 9 + 22 passed |
| `./bench validate` | 28/28 |
| `./bench validate --suite agentic-all` | 16/16 |
| `ruff check .` | clean |
| `mypy benchkit router.py` | clean, 23 files |

No live model was run: the endpoint path is exercised against a loopback stub
`/v1/models` server, so the suite does not depend on what happens to be serving
on the machine running it.

## Acceptance Criteria Verification

| # | Criterion | Status | Evidence |
|---|---|---|---|
| 1 | `--harness pi --endpoint <url> -m <model>` runs a suite end to end | ✅ | Constructor accepts it, `prepare()` stages the catalogue, `_env()`/`_argv()` address it, `available()` validates the model against the endpoint — `TestEndpointStaging`, `TestEndpointAvailability` |
| 2 | The user's own pi configuration is not mutated | ✅ | `test_the_users_catalogue_is_never_written` compares it byte-for-byte; `test_nothing_is_created_in_the_users_agent_dir` checks the whole directory listing; in endpoint mode the file is not opened at all |
| 3 | The three harnesses accept `--endpoint` consistently, and the docs no longer say pi cannot | ✅ | `test_every_harness_takes_the_same_endpoint_kwarg`; `_endpoint_kw` no longer branches on harness name; four docs corrected |
| 4 | pi without `--endpoint` is unchanged | ✅ | `TestWithoutAnEndpoint` — nothing staged, `PI_CODING_AGENT_DIR` untouched, the user's catalogue still resolves the model |

Closes #56
