### PR TITLE
feat(sweep): sweep serving configs and harnesses, rank setups (#57)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Run mypy
         run: uv run mypy benchkit router.py --ignore-missing-imports
 
+      - name: Run unit tests with coverage
+        run: uv run coverage run --source=benchkit --parallel-mode -m unittest discover -s tests -t tests
+
       - name: Run bench validate with coverage
         run: uv run coverage run --source=benchkit --parallel-mode -m benchkit.cli validate
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         run: uv run mypy benchkit router.py --ignore-missing-imports
 
       - name: Run unit tests with coverage
-        run: uv run coverage run --source=benchkit --parallel-mode -m unittest discover -s tests -t tests
+        run: uv run coverage run --source=benchkit --parallel-mode -m unittest discover -s tests -t .
 
       - name: Run bench validate with coverage
         run: uv run coverage run --source=benchkit --parallel-mode -m benchkit.cli validate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,35 @@ The gap is not cosmetic — on this repo's first such comparison the same model 
 through the built-in loop and 77.4 through pi. When you report a number, name the harness it
 came from.
 
+## Step 6b — sweep whole setups, not one axis
+
+Steps 4 and 6 vary one axis each. When the question is "what is the best setup on this
+machine", vary all three at once and let the report rank them:
+
+```bash
+./bench sweep --suite agentic-hard --title "setup sweep" --dry-run \
+  --setup config=qwen3.6-35b-a3b-nvfp4,thinking=both \
+  --setup config=qwen3.8-27b-nvfp4-dspark,thinking=both \
+  --setup config=qwen3.6-35b-a3b-nvfp4,harness=opencode,model=montimage-dgx-spark
+```
+
+Always dry-run first: it prints the matrix, the grouping, and exactly how many endpoint
+restarts the sweep would cause, without touching anything.
+
+Then, and only after a human has approved restarting the endpoint, re-run with
+`--yes-restart-endpoint`. Without that flag a sweep that needs a restart refuses to start —
+it never treats a non-interactive session as consent. A sweep whose setups carry no
+`config=` needs no approval at all: it measures the harness and thinking axes against
+whatever is already serving.
+
+Read the report's **Ranked setups** section the way it is written: one block per
+(harness, thinking mode), each with its own winner and its own noise verdict. There is no
+global winner across harnesses, on purpose — see the 67.4 / 77.4 spread in step 6.
+
+`configs/` holds recipes this cannot drive (llama.cpp, the env-tunable standalone server,
+the secondary gemma backend). `bench configs` marks each one and says why; naming one in a
+`--setup` is refused up front rather than halfway through.
+
 ## Step 7 — install the winner
 
 ```bash
@@ -161,7 +190,7 @@ row is a guess, not a known-good config.
   change that destroys the value of the entire repo.
 - **Never delete or overwrite an existing `results/` directory.** They are append-only; a
   superseded campaign stays next to the one that replaced it.
-- **Never restart a shared serving endpoint without explicit human approval.**
+- **Never restart a shared serving endpoint without explicit human approval.** `bench sweep` enforces this: it refuses to start unless a human approved the restarts interactively or passed `--yes-restart-endpoint`.
 - **Do not report a number you did not measure.** No estimating, no carrying a figure over
   from another machine, no quoting the model card.
 - **Report failures that were the harness's fault as such.** One `run_python` bug in this

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@ pip install -r requirements.txt          # openai>=1.40
 ./bench validate --suite agentic-all      # 16/16
 ./bench run --suite all --label "..."     # full evaluation
 ./bench compare <A> <B> --both-modes      # head-to-head
+./bench sweep --setup config=<c>,thinking=both --dry-run   # rank whole setups
 ./bench harness models                    # models your opencode/pi can reach
 ./bench harness run --harness opencode -m <p>/<m>   # benchmark one of them
 ./bench apply <config> --restart          # install winner
@@ -20,7 +21,7 @@ pip install -r requirements.txt          # openai>=1.40
 
 ## Environment variables
 
-All `BENCH_*` vars read by `benchkit/runner.py:Config.from_env()`:
+All `BENCH_*` vars read by `benchkit/runner.py:Config.from_env()`; full list with comments in `.env.example`:
 
 | Variable | Default | Purpose |
 |---|---|---|
@@ -35,15 +36,13 @@ All `BENCH_*` vars read by `benchkit/runner.py:Config.from_env()`:
 | `BENCH_HARNESS_ENDPOINT` | — | Point a harness at this endpoint, not its own providers |
 | `PI_CODING_AGENT_DIR` | — | pi agent directory |
 
-Full list with comments: `.env.example`.
-
 ## Architecture map
 
 ```
 ./
 ├── bench                # CLI entry point
 ├── benchkit/
-│   ├── cli.py           # validate, run, compare, report, harness, apply
+│   ├── cli.py           # validate, run, compare, sweep, report, harness, apply
 │   ├── runner.py        # Config + suite runner
 │   ├── suites/          # one-shot task definitions
 │   ├── agentic/         # agentic tasks + oracles
@@ -58,7 +57,7 @@ Full list with comments: `.env.example`.
 
 - **Never edit a task's tests, asserts or `check` to make a model pass.** That destroys the benchmark.
 - **Never delete or overwrite `results/`.** It is append-only.
-- **Never restart a shared serving endpoint without explicit human approval.**
+- **Never restart a shared serving endpoint without explicit human approval.** `bench sweep` refuses without `--yes-restart-endpoint` or an interactive yes.
 - **Always run both thinking modes** (`--thinking` and without). They are different products.
 - **Raise `--max-tokens` with `--thinking`** or reasoning eats the entire budget.
 - **Differences under ~8 points at `--samples 2` are noise.** Say so; raise `--samples`.

--- a/README.md
+++ b/README.md
@@ -153,6 +153,10 @@ single cross-harness "winner" would be reporting the harness. Each block names i
 winner and says whether the margin clears the noise floor for the sample count used (~8
 points at `--samples 2`, scaled by 1/sqrt(n) above that).
 
+The ranking is rebuildable from the result files alone — `./bench report <dir>/*.json
+--setups` regenerates it without re-running anything, so a sweep that finished but tripped
+over its report is not lost.
+
 Not every recipe in `configs/` can be swept — `bench configs` marks the ones that cannot and
 says why (a llama.cpp script, a standalone tunable server, a secondary backend on its own
 unit are all fine recipes, just not drivable by the `vllm-qwen` systemd machinery).

--- a/README.md
+++ b/README.md
@@ -109,12 +109,51 @@ program runs in a subprocess. It passes or it does not.
 | `./bench configs` | List known-good serving configs |
 | `./bench apply <name> [--restart]` | Install one as your live server config |
 | `./bench compare <model>...` | DGX box only: swap, run, restore, report — one command |
+| `./bench sweep --setup ...` | DGX box only: sweep serving config x harness x thinking mode and rank the *setups* |
 
 Full walkthrough: **[docs/REPRODUCING.md](docs/REPRODUCING.md)**.
 Running this as an AI agent: **[AGENTS.md](AGENTS.md)** — a runbook with checks and guardrails.
 Benchmarking through your own coding agent: **[docs/HARNESSES.md](docs/HARNESSES.md)**.
 Where this is going: **[ROADMAP.md](ROADMAP.md)** — next up is benchmarking through the
 coding harness you actually use (pi, opencode, Claude Code, Codex), not just our tool loop.
+
+## Sweeping setups, not just models
+
+A setup on your machine is three things at once: the serving config, the harness wrapped
+around the model, and whether thinking is on. `bench compare` sweeps only the model.
+`bench sweep` takes an explicit matrix of setups and ranks them:
+
+```bash
+./bench sweep --suite agentic-hard --title "27B dense vs 35B MoE" \
+  --setup config=qwen3.6-35b-a3b-nvfp4,thinking=both \
+  --setup config=qwen3.8-27b-nvfp4-dspark,thinking=both \
+  --setup config=qwen3.6-35b-a3b-nvfp4,harness=opencode,model=montimage-dgx-spark \
+  --dry-run
+```
+
+Four things worth knowing before you drop the `--dry-run`:
+
+- **The matrix is explicit, never a cross-product.** Independent `--configs`/`--harnesses`
+  flags would multiply into combinations that cannot exist. Each `--setup` is one real
+  combination; `thinking=both` is the only expansion, because thinking and non-thinking are
+  two products, not one row.
+- **One restart per serving config, not per setup.** Setups are grouped by config, so a
+  six-setup sweep over two configs restarts the endpoint twice.
+- **Every restart is gated.** Without `--yes-restart-endpoint` a sweep that would restart a
+  shared endpoint asks first, and refuses outright when it cannot ask. Dropping `config=`
+  from every setup sweeps the harness and thinking axes against whatever is already serving,
+  and never touches the launcher.
+- **The launcher you started with is put back** — on success and on failure, and a failing
+  restore is reported rather than allowed to bury the error that caused it.
+
+The report ranks setups *within* one harness and one thinking mode and nowhere else: the
+same weights score 67.4 through the built-in loop and 79.3 through opencode here, so a
+single cross-harness "winner" would be reporting the harness. Each block names its own
+winner and says whether the margin clears the ~8-point noise floor for the sample count used.
+
+Not every recipe in `configs/` can be swept — `bench configs` marks the ones that cannot and
+says why (a llama.cpp script, a standalone tunable server, a secondary backend on its own
+unit are all fine recipes, just not drivable by the `vllm-qwen` systemd machinery).
 
 ## The suites
 

--- a/README.md
+++ b/README.md
@@ -142,14 +142,16 @@ Four things worth knowing before you drop the `--dry-run`:
 - **Every restart is gated.** Without `--yes-restart-endpoint` a sweep that would restart a
   shared endpoint asks first, and refuses outright when it cannot ask. Dropping `config=`
   from every setup sweeps the harness and thinking axes against whatever is already serving,
-  and never touches the launcher.
+  and never touches the launcher. There is deliberately no "swap but do not restart" mode:
+  it would measure the previous config and file the result under the new one's name.
 - **The launcher you started with is put back** — on success and on failure, and a failing
   restore is reported rather than allowed to bury the error that caused it.
 
 The report ranks setups *within* one harness and one thinking mode and nowhere else: the
 same weights score 67.4 through the built-in loop and 79.3 through opencode here, so a
 single cross-harness "winner" would be reporting the harness. Each block names its own
-winner and says whether the margin clears the ~8-point noise floor for the sample count used.
+winner and says whether the margin clears the noise floor for the sample count used (~8
+points at `--samples 2`, scaled by 1/sqrt(n) above that).
 
 Not every recipe in `configs/` can be swept — `bench configs` marks the ones that cannot and
 says why (a llama.cpp script, a standalone tunable server, a secondary backend on its own

--- a/benchkit/cli.py
+++ b/benchkit/cli.py
@@ -130,6 +130,11 @@ def cmd_report(args):
     md = report.build(runs, title=args.title, question=args.question,
                       verdict=args.verdict, notes=notes, setups=args.setups)
     out = args.out or os.path.join(os.path.dirname(args.results[0]), "REPORT.md")
+    if os.path.exists(out) and not args.force:
+        # results/ is append-only, and the default output path lands straight in
+        # a finished campaign's directory.
+        raise SystemExit(f"refusing to overwrite an existing report: {out}\n"
+                         "Pass --out <path> to write elsewhere, or --force.")
     with open(out, "w") as f:
         f.write(md)
     print(f"written to {out}")
@@ -297,7 +302,8 @@ def cmd_sweep(args):
         raise SystemExit("refusing to overwrite files from an earlier campaign:\n"
                          + "\n".join(f"  {p}" for p in taken)
                          + "\nGive this sweep a different --title.")
-    print(f"suite={args.suite}  {len(setups)} setups  results -> {outdir}\n")
+    print(f"suite={args.suite}  {S._n(len(setups), 'setup')}  "
+          f"results -> {outdir}\n")
 
     paths = S.run_sweep(
         setups, outdir,
@@ -500,6 +506,8 @@ def main(argv=None):
     s.add_argument("--setups", action="store_true",
                    help="add the ranked-setups section, as `bench sweep` writes it "
                         "— rebuilds a sweep's ranking from its result files")
+    s.add_argument("--force", action="store_true",
+                   help="overwrite the output file if it already exists")
     s.add_argument("--out")
     s.set_defaults(func=cmd_report)
 

--- a/benchkit/cli.py
+++ b/benchkit/cli.py
@@ -185,6 +185,90 @@ def cmd_compare(args):
     return 0
 
 
+def _sweep_execute(args, setup, label):
+    """Run one setup row and return its (summary, results).
+
+    The two execution paths differ only in *what* wraps the model: benchkit's
+    own tool loop, or a real harness pointed at this endpoint. Both record the
+    serving config and harness on the run config, which is what lets the report
+    rank setups rather than models.
+    """
+    tasks = get(args.suite)
+    if not setup.harness:
+        cfg = runner.Config(
+            base_url=args.base_url, model=setup.model or args.model, label=label,
+            thinking=setup.thinking,
+            max_tokens=args.max_tokens_think if setup.thinking else args.max_tokens,
+            samples=args.samples, concurrency=args.concurrency,
+            test_timeout=args.test_timeout,
+            serving_config=setup.config, harness="")
+        return _execute_suite(args.suite, tasks, cfg, max_turns=args.max_turns)
+
+    from benchkit import harness as H
+    from benchkit.harness import models as hmodels
+    from benchkit.harness import runner as hrunner
+
+    if kind(args.suite) != "agentic":
+        raise SystemExit("harness setups need an agentic suite "
+                         "(agentic, agentic-hard, agentic-all)")
+    # A sweep exists to measure *this* endpoint, so a harness in a sweep is
+    # always pointed at it rather than at its own configured providers.
+    endpoint = args.endpoint or args.base_url
+    spec = setup.model or args.model
+    provider, model = hmodels.resolve(spec, [])
+    h = H.get(setup.harness, provider=provider, model=model, base_url=endpoint)
+    ok, detail = h.available()
+    if not ok:
+        raise SystemExit(f"harness {h.name!r} is not usable here: {detail}")
+    cfg = runner.Config(base_url=endpoint, model=h.model_spec, label=label,
+                        thinking=setup.thinking, max_tokens=0,
+                        samples=args.samples, concurrency=args.concurrency,
+                        test_timeout=args.test_timeout,
+                        serving_config=setup.config, harness=h.name)
+    return hrunner.run(h, tasks, cfg, on_result=_print_agentic,
+                       timeout=args.timeout, keep_dirs=False)
+
+
+def cmd_sweep(args):
+    """Sweep an explicit setup matrix and rank the setups, not the models.
+
+    `bench compare` answers "which model?". This answers "which *setup*?" --
+    serving config x harness x thinking mode -- with one endpoint restart per
+    distinct serving config, behind the shared-endpoint approval gate, and with
+    the launcher that was active when the sweep began put back on the way out.
+    """
+    from benchkit import serving, sweep as S
+
+    setups = S.parse_setups(args.setups, known_harnesses=_harness_names(),
+                            default_model=args.model)
+    if args.dry_run:
+        S.check_sweepable(setups, serving)
+        print(S.plan(setups, default_model=args.model))
+        needed = S.configs_needing_swap(setups)
+        print("\nendpoint restarts: " + (", ".join(needed) if needed else "none"))
+        if needed and not args.yes_restart_endpoint:
+            print("  -> would ask for approval first "
+                  "(or pass --yes-restart-endpoint)")
+        return 0
+
+    outdir = os.path.join(RESULTS, f"{_stamp()}-{_slug(args.title)}")
+    print(f"suite={args.suite}  {len(setups)} setups  results -> {outdir}\n")
+
+    paths = S.run_sweep(
+        setups, outdir,
+        execute=lambda setup, label: _sweep_execute(args, setup, label),
+        serving=serving, assume_yes=args.yes_restart_endpoint,
+        restart=args.restart, default_model=args.model)
+
+    md = report.build([report.load(p) for p in paths], title=args.title,
+                      question=args.question, setups=True)
+    out = os.path.join(outdir, "REPORT.md")
+    with open(out, "w") as f:
+        f.write(md)
+    print(f"\nreport written to {out}")
+    return 0
+
+
 def cmd_harness(args):
     """Run a suite through a real coding harness, on whichever model you pick.
 
@@ -288,9 +372,14 @@ def _endpoint_kw(endpoint):
 def cmd_configs(args):
     from benchkit import serving
     active = serving.current_model()
-    for name, model_id, _ in serving.list_configs():
+    ok, skipped = serving.sweepable_configs()
+    for name, model_id, _ in ok:
         mark = " (active model)" if model_id == active else ""
         print(f"{name:<34} {model_id}{mark}")
+    for name, reason in skipped:
+        # still a known-good recipe, just not one `bench sweep` can install and
+        # restart -- say why here rather than crashing halfway through a sweep.
+        print(f"{name:<34} not sweepable: {reason}")
     return 0
 
 
@@ -381,6 +470,41 @@ def main(argv=None):
     s.add_argument("--no-restore", dest="restore", action="store_false",
                    help="leave the last model serving instead of restoring the original")
     s.set_defaults(func=cmd_compare)
+
+    s = sub.add_parser("sweep",
+                       help="sweep an explicit setup matrix (config x harness x "
+                            "thinking) and rank the setups")
+    common(s)
+    s.add_argument("--setup", dest="setups", action="append", default=[],
+                   metavar="config=...,harness=...,model=...,thinking=...",
+                   help="one setup, repeatable. Keys: config (a `bench configs` "
+                        "name; omit to use whatever is already serving), harness "
+                        "(omit for benchkit's own loop), model, thinking "
+                        "(on|off|both), label. Setups are explicit on purpose: "
+                        "independent axes cross-product into combinations that "
+                        "cannot exist.")
+    s.add_argument("--title", default="Setup sweep")
+    s.add_argument("--question")
+    s.add_argument("--max-tokens", type=int, default=6000)
+    s.add_argument("--max-tokens-think", type=int, default=16000)
+    s.add_argument("--max-turns", type=int, default=25,
+                   help="agentic suite: tool-calling turns before the task is abandoned")
+    s.add_argument("--timeout", type=int, default=900,
+                   help="harness setups: seconds per task")
+    s.add_argument("--endpoint", default="",
+                   help="endpoint to point harness setups at "
+                        "(default: --base-url, i.e. the endpoint being swept)")
+    s.add_argument("--yes-restart-endpoint", action="store_true",
+                   help="approve restarting the shared serving endpoint once per "
+                        "serving config in the matrix. Without it a sweep that "
+                        "needs a restart refuses to start (CLAUDE.md: never "
+                        "restart a shared endpoint without explicit approval).")
+    s.add_argument("--no-restart", dest="restart", action="store_false",
+                   help="install each config without restarting the service — "
+                        "for rehearsing a sweep, not for measuring one")
+    s.add_argument("--dry-run", action="store_true",
+                   help="print the matrix and the restart plan, run nothing")
+    s.set_defaults(func=cmd_sweep)
 
     s = sub.add_parser("harness",
                        help="run a suite through a real coding harness (opencode, pi, ...)")

--- a/benchkit/cli.py
+++ b/benchkit/cli.py
@@ -128,7 +128,7 @@ def cmd_report(args):
     runs = [report.load(p) for p in args.results]
     notes = open(args.notes).read() if args.notes else None
     md = report.build(runs, title=args.title, question=args.question,
-                      verdict=args.verdict, notes=notes)
+                      verdict=args.verdict, notes=notes, setups=args.setups)
     out = args.out or os.path.join(os.path.dirname(args.results[0]), "REPORT.md")
     with open(out, "w") as f:
         f.write(md)
@@ -201,6 +201,31 @@ def _sweep_model(args, setup):
         raise SystemExit(f"setup {setup.resolved_label(args.model)!r}: {e}") from e
 
 
+def _sweep_harness(args, setup):
+    """Build and probe the harness one setup needs. Every failure is a user error.
+
+    Called from the pre-flight pass as well as from the run, so a wrong suite
+    kind, a bad model spec or an uninstalled harness is reported before the
+    first endpoint restart rather than after it -- a shared endpoint should
+    never be restarted twice to discover a typo.
+    """
+    from benchkit import harness as H
+
+    if kind(args.suite) != "agentic":
+        raise SystemExit(f"setup {setup.resolved_label(args.model)!r} runs through "
+                         f"a harness, which needs an agentic suite; --suite is "
+                         f"{args.suite!r} (try agentic, agentic-hard, agentic-all)")
+    # A sweep exists to measure *this* endpoint, so a harness in a sweep is
+    # always pointed at it rather than at its own configured providers.
+    endpoint = args.endpoint or args.base_url
+    provider, model = _sweep_model(args, setup)
+    h = H.get(setup.harness, provider=provider, model=model, base_url=endpoint)
+    ok, detail = h.available()
+    if not ok:
+        raise SystemExit(f"harness {h.name!r} is not usable here: {detail}")
+    return h
+
+
 def _sweep_execute(args, setup, label):
     """Run one setup row and return its (summary, results).
 
@@ -217,28 +242,19 @@ def _sweep_execute(args, setup, label):
             max_tokens=args.max_tokens_think if setup.thinking else args.max_tokens,
             samples=args.samples, concurrency=args.concurrency,
             test_timeout=args.test_timeout,
-            serving_config=setup.config, harness="")
+            serving_config=setup.config or setup.config_name, harness="")
         return _execute_suite(args.suite, tasks, cfg, max_turns=args.max_turns)
 
-    from benchkit import harness as H
     from benchkit.harness import runner as hrunner
 
-    if kind(args.suite) != "agentic":
-        raise SystemExit("harness setups need an agentic suite "
-                         "(agentic, agentic-hard, agentic-all)")
-    # A sweep exists to measure *this* endpoint, so a harness in a sweep is
-    # always pointed at it rather than at its own configured providers.
+    h = _sweep_harness(args, setup)
     endpoint = args.endpoint or args.base_url
-    provider, model = _sweep_model(args, setup)
-    h = H.get(setup.harness, provider=provider, model=model, base_url=endpoint)
-    ok, detail = h.available()
-    if not ok:
-        raise SystemExit(f"harness {h.name!r} is not usable here: {detail}")
     cfg = runner.Config(base_url=endpoint, model=h.model_spec, label=label,
                         thinking=setup.thinking, max_tokens=0,
                         samples=args.samples, concurrency=args.concurrency,
                         test_timeout=args.test_timeout,
-                        serving_config=setup.config, harness=h.name)
+                        serving_config=setup.config or setup.config_name,
+                        harness=h.name)
     return hrunner.run(h, tasks, cfg, on_result=_print_agentic,
                        timeout=args.timeout, keep_dirs=False)
 
@@ -268,16 +284,19 @@ def cmd_sweep(args):
     S.check_sweepable(setups, serving)
     for setup in setups:
         if setup.harness:
-            _sweep_model(args, setup)
+            _sweep_harness(args, setup)
 
+    # results/ is append-only and _stamp() is day-granular, so a second sweep
+    # with the same title on the same day would land in the same directory.
+    # Every collision is found now, not after a restart and an hour of runs.
     outdir = os.path.join(RESULTS, f"{_stamp()}-{_slug(args.title)}")
     out = os.path.join(outdir, "REPORT.md")
-    if os.path.exists(out):
-        # results/ is append-only, and _stamp() is day-granular: a second sweep
-        # with the same title on the same day would silently bury the first
-        # campaign's report while orphaning its result files.
-        raise SystemExit(f"refusing to overwrite an existing report: {out}\n"
-                         "Give this sweep a different --title.")
+    taken = [p for p in [out] + S.result_paths(setups, outdir, args.model)
+             if os.path.exists(p)]
+    if taken:
+        raise SystemExit("refusing to overwrite files from an earlier campaign:\n"
+                         + "\n".join(f"  {p}" for p in taken)
+                         + "\nGive this sweep a different --title.")
     print(f"suite={args.suite}  {len(setups)} setups  results -> {outdir}\n")
 
     paths = S.run_sweep(
@@ -478,6 +497,9 @@ def main(argv=None):
     s.add_argument("--question")
     s.add_argument("--verdict")
     s.add_argument("--notes", help="path to a Markdown file inserted as analysis")
+    s.add_argument("--setups", action="store_true",
+                   help="add the ranked-setups section, as `bench sweep` writes it "
+                        "— rebuilds a sweep's ranking from its result files")
     s.add_argument("--out")
     s.set_defaults(func=cmd_report)
 

--- a/benchkit/cli.py
+++ b/benchkit/cli.py
@@ -185,6 +185,22 @@ def cmd_compare(args):
     return 0
 
 
+def _sweep_model(args, setup):
+    """Resolve one harness setup's model spec, as a user error not a traceback.
+
+    Called once up front for the whole matrix as well as at run time, so a typo
+    is answered before the first endpoint restart rather than after it.
+    """
+    from benchkit.harness import models as hmodels
+    spec = setup.model or args.model
+    try:
+        # in endpoint mode the id is whatever the server reports, so it is taken
+        # literally; there is no catalogue to match against
+        return hmodels.resolve(spec, [])
+    except hmodels.ModelSpecError as e:
+        raise SystemExit(f"setup {setup.resolved_label(args.model)!r}: {e}") from e
+
+
 def _sweep_execute(args, setup, label):
     """Run one setup row and return its (summary, results).
 
@@ -205,7 +221,6 @@ def _sweep_execute(args, setup, label):
         return _execute_suite(args.suite, tasks, cfg, max_turns=args.max_turns)
 
     from benchkit import harness as H
-    from benchkit.harness import models as hmodels
     from benchkit.harness import runner as hrunner
 
     if kind(args.suite) != "agentic":
@@ -214,8 +229,7 @@ def _sweep_execute(args, setup, label):
     # A sweep exists to measure *this* endpoint, so a harness in a sweep is
     # always pointed at it rather than at its own configured providers.
     endpoint = args.endpoint or args.base_url
-    spec = setup.model or args.model
-    provider, model = hmodels.resolve(spec, [])
+    provider, model = _sweep_model(args, setup)
     h = H.get(setup.harness, provider=provider, model=model, base_url=endpoint)
     ok, detail = h.available()
     if not ok:
@@ -251,18 +265,29 @@ def cmd_sweep(args):
                   "(or pass --yes-restart-endpoint)")
         return 0
 
+    S.check_sweepable(setups, serving)
+    for setup in setups:
+        if setup.harness:
+            _sweep_model(args, setup)
+
     outdir = os.path.join(RESULTS, f"{_stamp()}-{_slug(args.title)}")
+    out = os.path.join(outdir, "REPORT.md")
+    if os.path.exists(out):
+        # results/ is append-only, and _stamp() is day-granular: a second sweep
+        # with the same title on the same day would silently bury the first
+        # campaign's report while orphaning its result files.
+        raise SystemExit(f"refusing to overwrite an existing report: {out}\n"
+                         "Give this sweep a different --title.")
     print(f"suite={args.suite}  {len(setups)} setups  results -> {outdir}\n")
 
     paths = S.run_sweep(
         setups, outdir,
         execute=lambda setup, label: _sweep_execute(args, setup, label),
         serving=serving, assume_yes=args.yes_restart_endpoint,
-        restart=args.restart, default_model=args.model)
+        default_model=args.model)
 
     md = report.build([report.load(p) for p in paths], title=args.title,
                       question=args.question, setups=True)
-    out = os.path.join(outdir, "REPORT.md")
     with open(out, "w") as f:
         f.write(md)
     print(f"\nreport written to {out}")
@@ -376,10 +401,11 @@ def cmd_configs(args):
     for name, model_id, _ in ok:
         mark = " (active model)" if model_id == active else ""
         print(f"{name:<34} {model_id}{mark}")
-    for name, reason in skipped:
+    for name, model_id, reason in skipped:
         # still a known-good recipe, just not one `bench sweep` can install and
         # restart -- say why here rather than crashing halfway through a sweep.
-        print(f"{name:<34} not sweepable: {reason}")
+        mark = " (active model)" if model_id == active else ""
+        print(f"{name:<34} {model_id}{mark}\n{'':<34} not sweepable: {reason}")
     return 0
 
 
@@ -499,9 +525,6 @@ def main(argv=None):
                         "serving config in the matrix. Without it a sweep that "
                         "needs a restart refuses to start (CLAUDE.md: never "
                         "restart a shared endpoint without explicit approval).")
-    s.add_argument("--no-restart", dest="restart", action="store_false",
-                   help="install each config without restarting the service — "
-                        "for rehearsing a sweep, not for measuring one")
     s.add_argument("--dry-run", action="store_true",
                    help="print the matrix and the restart plan, run nothing")
     s.set_defaults(func=cmd_sweep)

--- a/benchkit/report.py
+++ b/benchkit/report.py
@@ -9,6 +9,12 @@ import os
 
 BAR = "xychart-beta"
 
+#: at 2 samples per task, anything under this many points is noise, not signal
+NOISE_POINTS = 8.0
+
+#: what a run that used benchkit's own tool loop, rather than a harness, is called
+BUILTIN_HARNESS = "built-in loop"
+
 
 def load(path):
     with open(path) as f:
@@ -57,7 +63,101 @@ def _chart(title, y_label, categories, values, y_max=None, kind="bar"):
             f"    {kind} [{vals}]\n```\n")
 
 
-def build(runs, title, question=None, verdict=None, notes=None, short_labels=None):
+def _setup_of(run):
+    """The (harness, thinking, config, model) a run came from, best-effort.
+
+    `bench sweep` records the serving config and harness on the run config, so
+    a swept result is fully attributed. Older result files predate those fields
+    and fall back to whatever the harness block recorded, then to the built-in
+    loop -- an unlabelled row is still reported, just as "not recorded".
+    """
+    s = run["summary"]
+    cfg = s["config"]
+    harness = cfg.get("harness") or (s.get("harness") or {}).get("name") or BUILTIN_HARNESS
+    return dict(
+        harness=harness,
+        thinking=bool(cfg.get("thinking")),
+        config=cfg.get("serving_config") or "not recorded",
+        model=cfg.get("served_model_id") or cfg.get("model") or "?",
+        samples=cfg.get("samples"),
+    )
+
+
+def _score_of(summary):
+    """(value, metric-name) — agent score where it exists, else pass@1."""
+    if summary.get("agent_score") is not None:
+        return summary["agent_score"] * 100, "Agent score"
+    return (summary.get("pass_at_1") or 0) * 100, "pass@1"
+
+
+def rank_setups(runs, labels):
+    """Markdown ranking setups *within* a comparable block, never across them.
+
+    A block is one harness in one thinking mode. That boundary is not
+    fastidiousness: this repo's own README records 67.4 through the built-in
+    loop against 79.3 through opencode on identical weights, so a table that
+    ranks an opencode row above a built-in-loop row is reporting the harness,
+    not the setup. Thinking and non-thinking are likewise two products, never
+    two candidates for one crown. Inside a block the serving config and the
+    model are the axes actually being compared, and there the winner is real --
+    subject to the sample-count noise floor, which every block states.
+    """
+    S = [r["summary"] for r in runs]
+    setups = [_setup_of(r) for r in runs]
+    blocks = {}
+    for i, st in enumerate(setups):
+        blocks.setdefault((st["harness"], st["thinking"]), []).append(i)
+
+    out = ["## Ranked setups\n"]
+    out.append("A setup is the serving config, the harness and the thinking mode "
+               "together. Scores are ranked **within** one harness and one thinking "
+               "mode and nowhere else: the same weights score differently through "
+               "different harnesses (67.4 through the built-in loop against 79.3 "
+               "through opencode, in this repo's own results), and thinking and "
+               "non-thinking are two products, not two candidates. There is "
+               "deliberately no single cross-harness winner below.\n")
+
+    for (harness, thinking), idx in blocks.items():
+        metric = "Agent score" if all(S[i].get("agent_score") is not None
+                                      for i in idx) else "pass@1"
+        scored = sorted(idx, key=lambda i: -_score_of(S[i])[0])
+        out.append(f"### {harness} · thinking {'ON' if thinking else 'OFF'}\n")
+        out.append(f"| Rank | Serving config | Model | {metric} | Samples |\n"
+                   "|---|---|---|---|---|")
+        for rank, i in enumerate(scored, 1):
+            st = setups[i]
+            value = (_score_of(S[i])[0] if metric == "Agent score"
+                     else (S[i].get("pass_at_1") or 0) * 100)
+            cell = f"**{value:.1f}**" if rank == 1 else f"{value:.1f}"
+            name = f"**{labels[i]}**" if rank == 1 else labels[i]
+            out.append(f"| {rank} | `{st['config']}` | {st['model']} — {name} "
+                       f"| {cell} | {st['samples']} |")
+        out.append("")
+        best = scored[0]
+        best_v = _score_of(S[best])[0]
+        samples = setups[best]["samples"]
+        if len(scored) == 1:
+            out.append(f"**Winner: {labels[best]}** — the only setup in this block, "
+                       "so this is a measurement, not a comparison.\n")
+            continue
+        runner_up = scored[1]
+        margin = best_v - _score_of(S[runner_up])[0]
+        verdict = (f"**Winner: {labels[best]}** — {best_v:.1f} against "
+                   f"{_score_of(S[runner_up])[0]:.1f} for {labels[runner_up]}, "
+                   f"a margin of {margin:.1f} points. ")
+        if margin < NOISE_POINTS:
+            verdict += (f"That is **inside the ~{NOISE_POINTS:.0f}-point noise floor** at "
+                        f"{samples} samples per task — treat it as a tie and re-run "
+                        "with more samples before acting on it.")
+        else:
+            verdict += (f"That clears the ~{NOISE_POINTS:.0f}-point noise floor at "
+                        f"{samples} samples per task.")
+        out.append(verdict + "\n")
+    return "\n".join(out)
+
+
+def build(runs, title, question=None, verdict=None, notes=None, short_labels=None,
+          setups=False):
     """runs: list of loaded result dicts. Returns Markdown source."""
     labels = [_label(r) for r in runs]
     short = short_labels or [_short(r, line) for r, line in zip(runs, labels)]
@@ -186,6 +286,9 @@ def build(runs, title, question=None, verdict=None, notes=None, short_labels=Non
     elif agentic:
         out.append("<sub>*Valid calls* = tool calls that did not error. *Turn-limit* = runs "
                    "abandoned after exhausting the turn budget without finishing.</sub>\n")
+
+    if setups:
+        out.append(rank_setups(runs, labels))
 
     # --- charts ---
     out.append(_chart("Solve rate (%)" if agentic else "pass@1 (%)",

--- a/benchkit/report.py
+++ b/benchkit/report.py
@@ -91,6 +91,52 @@ def _setup_of(run):
     )
 
 
+def _blocks(runs):
+    """{(harness, thinking): [run index, ...]} — the only comparable groupings.
+
+    One harness in one thinking mode. Everything that names a winner, bolds a
+    row or pairs two runs against each other has to respect this boundary, or
+    the report crowns the harness instead of the setup.
+    """
+    blocks = {}
+    for i, r in enumerate(runs):
+        st = _setup_of(r)
+        blocks.setdefault((st["harness"], st["thinking"]), []).append(i)
+    return blocks
+
+
+def _block_key(S, idx):
+    """Which metric ranks this block: agent score only if every row has one."""
+    return ("agent_score"
+            if all(S[i].get("agent_score") is not None for i in idx)
+            else "pass_at_1")
+
+
+def _setup_short(runs):
+    """Chart-axis labels for a sweep, keyed on the axes a sweep actually varies.
+
+    `_short` keys on the model, which is exactly what a sweep holds constant —
+    it would render three different setups as three identical bars.
+    """
+    out = []
+    for r in runs:
+        st = _setup_of(r)
+        harness = "builtin" if st["harness"] == BUILTIN_HARNESS else st["harness"]
+        cfg = st["config"]
+        cfg = "active" if cfg.startswith("(active") else (
+            "?" if cfg == "not recorded" else cfg)
+        out.append(f"{harness[:7]} {cfg[:8]} {'ON' if st['thinking'] else 'OFF'}")
+    # suffix *every* occurrence of a repeated label, not just the first: a
+    # chart axis reading "opencod cfg-a OFF" twice names neither run.
+    totals = {label: out.count(label) for label in set(out)}
+    seen = {}
+    for i, label in enumerate(out):
+        if totals[label] > 1:
+            seen[label] = seen.get(label, 0) + 1
+            out[i] = f"{label} {seen[label]}"
+    return out
+
+
 def noise_floor(samples):
     """Points below which a difference is noise, for this many samples per task.
 
@@ -120,9 +166,7 @@ def rank_setups(runs, labels):
     """
     S = [r["summary"] for r in runs]
     setups = [_setup_of(r) for r in runs]
-    blocks = {}
-    for i, st in enumerate(setups):
-        blocks.setdefault((st["harness"], st["thinking"]), []).append(i)
+    blocks = _blocks(runs)
 
     out = ["## Ranked setups\n"]
     out.append("A setup is the serving config, the harness and the thinking mode "
@@ -137,11 +181,10 @@ def rank_setups(runs, labels):
         # One metric decides the whole block. A block where any run predates
         # oracle-par efficiency falls back to pass@1 for *every* row, so the
         # ranking, the cells and the margin can never quote different rulers.
-        agentic = all(S[i].get("agent_score") is not None for i in idx)
-        metric = "Agent score" if agentic else "pass@1"
+        key = _block_key(S, idx)
+        metric = "Agent score" if key == "agent_score" else "pass@1"
 
-        def value(i, agentic=agentic):
-            key = "agent_score" if agentic else "pass_at_1"
+        def value(i, key=key):
             return (S[i].get(key) or 0) * 100
 
         ranked = sorted(idx, key=lambda i: -value(i))
@@ -156,7 +199,11 @@ def rank_setups(runs, labels):
                        f"| {cell} | {st['samples']} |")
         out.append("")
         best = ranked[0]
-        samples = setups[best]["samples"]
+        # the floor is set by the *noisiest* row in the block: quoting the
+        # winner's sample count would understate the noise whenever the
+        # runner-up ran at fewer samples.
+        recorded = [setups[i]["samples"] for i in idx]
+        samples = min((r or NOISE_SAMPLES) for r in recorded)
         if len(ranked) == 1:
             out.append(f"**Winner: {labels[best]}** — the only setup in this block, "
                        "so this is a measurement, not a comparison.\n")
@@ -167,8 +214,9 @@ def rank_setups(runs, labels):
         verdict = (f"**Winner: {labels[best]}** — {value(best):.1f} against "
                    f"{value(runner_up):.1f} for {labels[runner_up]}, "
                    f"a margin of {margin:.1f} points. ")
-        where = (f"at {samples} samples per task" if samples
-                 else "at the default sample count (this run did not record one)")
+        where = f"at {samples} samples per task"
+        if any(r is None for r in recorded):
+            where += " (assumed — not every run in this block recorded one)"
         scale = (f"~{floor:.1f} points {where} "
                  f"(~{NOISE_POINTS:.0f} at {NOISE_SAMPLES}, scaled by 1/sqrt(n))")
         if margin < floor:
@@ -184,7 +232,8 @@ def build(runs, title, question=None, verdict=None, notes=None, short_labels=Non
           setups=False):
     """runs: list of loaded result dicts. Returns Markdown source."""
     labels = [_label(r) for r in runs]
-    short = short_labels or [_short(r, line) for r, line in zip(runs, labels)]
+    short = short_labels or (_setup_short(runs) if setups
+                             else [_short(r, line) for r, line in zip(runs, labels)])
     S = [r["summary"] for r in runs]
 
     out = [f"# {title}\n"]
@@ -260,8 +309,19 @@ def build(runs, title, question=None, verdict=None, notes=None, short_labels=Non
     scored = agentic and all(s.get("agent_score") is not None for s in S)
     out.append("## Results\n")
     # rank agentic runs on the agent score; solve rate ties too often to rank on
-    best = max(range(len(S)),
-               key=lambda i: (S[i]["agent_score"] if scored else S[i]["pass_at_1"]))
+    if setups:
+        # A sweep spans several harnesses and both thinking modes, so a single
+        # bolded row would be a cross-harness verdict printed directly above the
+        # section explaining that no such verdict exists. Bold each comparable
+        # block's leader instead.
+        leaders = set()
+        for idx in _blocks(runs).values():
+            key = _block_key(S, idx)
+            leaders.add(max(idx, key=lambda i, key=key: (S[i].get(key) or 0)))
+    else:
+        leaders = {max(range(len(S)),
+                       key=lambda i: (S[i]["agent_score"] if scored
+                                      else S[i]["pass_at_1"]))}
     if scored:
         out.append("| Run | Agent score | Solved | Efficiency | Mean calls | Par "
                    "| Valid calls | Turn-limit | Wall |\n"
@@ -275,9 +335,9 @@ def build(runs, title, question=None, verdict=None, notes=None, short_labels=Non
                    "| Truncated | tok/s |\n|---|---|---|---|---|---|---|---|---|")
     for i, s in enumerate(S):
         d = s["by_difficulty"]
-        name = f"**{labels[i]}**" if i == best else labels[i]
+        name = f"**{labels[i]}**" if i in leaders else labels[i]
         if scored:
-            score = (f"**{s['agent_score'] * 100:.1f}**" if i == best
+            score = (f"**{s['agent_score'] * 100:.1f}**" if i in leaders
                      else f"{s['agent_score'] * 100:.1f}")
             out.append(f"| {name} | {score} "
                        f"| {_fmt(s['pass_at_1'], pct=True)} "
@@ -312,6 +372,10 @@ def build(runs, title, question=None, verdict=None, notes=None, short_labels=Non
                    "abandoned after exhausting the turn budget without finishing.</sub>\n")
 
     if setups:
+        out.append("<sub>Bold marks the leader **within** its own harness and thinking "
+                   "mode — see *Ranked setups* below for the verdict. Rows from "
+                   "different harnesses are not comparable, and neither are the "
+                   "charts that follow.</sub>\n")
         out.append(rank_setups(runs, labels))
 
     # --- charts ---
@@ -345,8 +409,16 @@ def build(runs, title, question=None, verdict=None, notes=None, short_labels=Non
     out.append("<sub>" + " · ".join(f"Line {i+1} = {line}" for i, line in enumerate(labels)) + "</sub>\n")
 
     # --- per-task disagreement between best and runner-up ---
-    if len(S) >= 2:
-        order = sorted(range(len(S)), key=lambda i: -S[i]["pass_at_1"])[:2]
+    # A head-to-head across harnesses or thinking modes is the cross-block
+    # comparison the ranking exists to forbid, so in a sweep the pair must come
+    # from one block -- and if no block holds two runs, there is no pair.
+    pool = range(len(S))
+    if setups:
+        candidates = [idx for idx in _blocks(runs).values() if len(idx) >= 2]
+        pool = max(candidates,
+                   key=lambda idx: max(S[i]["pass_at_1"] for i in idx)) if candidates else []
+    if len(pool) >= 2:
+        order = sorted(pool, key=lambda i: -S[i]["pass_at_1"])[:2]
         a, b = order
         ta, tb = S[a]["by_task"], S[b]["by_task"]
         rows = [(t, ta[t], tb.get(t, 0.0)) for t in sorted(ta) if ta[t] != tb.get(t, 0.0)]

--- a/benchkit/report.py
+++ b/benchkit/report.py
@@ -74,11 +74,18 @@ def _setup_of(run):
     """
     s = run["summary"]
     cfg = s["config"]
-    harness = cfg.get("harness") or (s.get("harness") or {}).get("name") or BUILTIN_HARNESS
+    # harness.describe() emits "harness" (base.py/opencode.py/pi.py/claudecode.py),
+    # not "name" -- reading the wrong key here would file every legacy harness
+    # run under the built-in loop and rank three harnesses inside one block.
+    block = s.get("harness") or {}
+    harness = cfg.get("harness") or block.get("harness") or block.get("name") \
+        or BUILTIN_HARNESS
     return dict(
         harness=harness,
         thinking=bool(cfg.get("thinking")),
         config=cfg.get("serving_config") or "not recorded",
+        # a swept row that deliberately used the live launcher says so; only a
+        # file that never recorded the field at all is "not recorded"
         model=cfg.get("served_model_id") or cfg.get("model") or "?",
         samples=cfg.get("samples"),
     )
@@ -160,7 +167,9 @@ def rank_setups(runs, labels):
         verdict = (f"**Winner: {labels[best]}** — {value(best):.1f} against "
                    f"{value(runner_up):.1f} for {labels[runner_up]}, "
                    f"a margin of {margin:.1f} points. ")
-        scale = (f"~{floor:.1f} points at {samples} samples per task "
+        where = (f"at {samples} samples per task" if samples
+                 else "at the default sample count (this run did not record one)")
+        scale = (f"~{floor:.1f} points {where} "
                  f"(~{NOISE_POINTS:.0f} at {NOISE_SAMPLES}, scaled by 1/sqrt(n))")
         if margin < floor:
             verdict += (f"That is **inside the noise floor** of {scale} — treat it as "

--- a/benchkit/report.py
+++ b/benchkit/report.py
@@ -9,8 +9,9 @@ import os
 
 BAR = "xychart-beta"
 
-#: at 2 samples per task, anything under this many points is noise, not signal
+#: CLAUDE.md's noise floor, calibrated at 2 samples per task
 NOISE_POINTS = 8.0
+NOISE_SAMPLES = 2
 
 #: what a run that used benchkit's own tool loop, rather than a harness, is called
 BUILTIN_HARNESS = "built-in loop"
@@ -83,21 +84,29 @@ def _setup_of(run):
     )
 
 
-def _score_of(summary):
-    """(value, metric-name) — agent score where it exists, else pass@1."""
-    if summary.get("agent_score") is not None:
-        return summary["agent_score"] * 100, "Agent score"
-    return (summary.get("pass_at_1") or 0) * 100, "pass@1"
+def noise_floor(samples):
+    """Points below which a difference is noise, for this many samples per task.
+
+    CLAUDE.md fixes the floor at ~8 points at `--samples 2`. Sampling error
+    shrinks as 1/sqrt(n), so quoting that same 8 points beside a 10-sample run
+    would be pessimistic, and quoting it beside a 1-sample run would be a lie.
+    The scaled figure is still an approximation, and it is named as one.
+    """
+    try:
+        n = max(1, int(samples or NOISE_SAMPLES))
+    except (TypeError, ValueError):
+        n = NOISE_SAMPLES
+    return NOISE_POINTS * (NOISE_SAMPLES / n) ** 0.5
 
 
 def rank_setups(runs, labels):
     """Markdown ranking setups *within* a comparable block, never across them.
 
     A block is one harness in one thinking mode. That boundary is not
-    fastidiousness: this repo's own README records 67.4 through the built-in
-    loop against 79.3 through opencode on identical weights, so a table that
-    ranks an opencode row above a built-in-loop row is reporting the harness,
-    not the setup. Thinking and non-thinking are likewise two products, never
+    fastidiousness: this repo's own harness-spread campaign in `results/`
+    records a swing on identical weights as large as a model change, so a table
+    that ranks an opencode row above a built-in-loop row is reporting the
+    harness, not the setup. Thinking and non-thinking are likewise two products, never
     two candidates for one crown. Inside a block the serving config and the
     model are the axes actually being compared, and there the winner is real --
     subject to the sample-count noise floor, which every block states.
@@ -111,47 +120,53 @@ def rank_setups(runs, labels):
     out = ["## Ranked setups\n"]
     out.append("A setup is the serving config, the harness and the thinking mode "
                "together. Scores are ranked **within** one harness and one thinking "
-               "mode and nowhere else: the same weights score differently through "
-               "different harnesses (67.4 through the built-in loop against 79.3 "
-               "through opencode, in this repo's own results), and thinking and "
-               "non-thinking are two products, not two candidates. There is "
-               "deliberately no single cross-harness winner below.\n")
+               "mode and nowhere else: identical weights score materially "
+               "differently through different harnesses — see the harness-spread "
+               "campaign in `results/` — and thinking and non-thinking are two "
+               "products, not two candidates. There is deliberately no single "
+               "cross-harness winner below.\n")
 
     for (harness, thinking), idx in blocks.items():
-        metric = "Agent score" if all(S[i].get("agent_score") is not None
-                                      for i in idx) else "pass@1"
-        scored = sorted(idx, key=lambda i: -_score_of(S[i])[0])
+        # One metric decides the whole block. A block where any run predates
+        # oracle-par efficiency falls back to pass@1 for *every* row, so the
+        # ranking, the cells and the margin can never quote different rulers.
+        agentic = all(S[i].get("agent_score") is not None for i in idx)
+        metric = "Agent score" if agentic else "pass@1"
+
+        def value(i, agentic=agentic):
+            key = "agent_score" if agentic else "pass_at_1"
+            return (S[i].get(key) or 0) * 100
+
+        ranked = sorted(idx, key=lambda i: -value(i))
         out.append(f"### {harness} · thinking {'ON' if thinking else 'OFF'}\n")
         out.append(f"| Rank | Serving config | Model | {metric} | Samples |\n"
                    "|---|---|---|---|---|")
-        for rank, i in enumerate(scored, 1):
+        for rank, i in enumerate(ranked, 1):
             st = setups[i]
-            value = (_score_of(S[i])[0] if metric == "Agent score"
-                     else (S[i].get("pass_at_1") or 0) * 100)
-            cell = f"**{value:.1f}**" if rank == 1 else f"{value:.1f}"
+            cell = f"**{value(i):.1f}**" if rank == 1 else f"{value(i):.1f}"
             name = f"**{labels[i]}**" if rank == 1 else labels[i]
             out.append(f"| {rank} | `{st['config']}` | {st['model']} — {name} "
                        f"| {cell} | {st['samples']} |")
         out.append("")
-        best = scored[0]
-        best_v = _score_of(S[best])[0]
+        best = ranked[0]
         samples = setups[best]["samples"]
-        if len(scored) == 1:
+        if len(ranked) == 1:
             out.append(f"**Winner: {labels[best]}** — the only setup in this block, "
                        "so this is a measurement, not a comparison.\n")
             continue
-        runner_up = scored[1]
-        margin = best_v - _score_of(S[runner_up])[0]
-        verdict = (f"**Winner: {labels[best]}** — {best_v:.1f} against "
-                   f"{_score_of(S[runner_up])[0]:.1f} for {labels[runner_up]}, "
+        runner_up = ranked[1]
+        margin = value(best) - value(runner_up)
+        floor = noise_floor(samples)
+        verdict = (f"**Winner: {labels[best]}** — {value(best):.1f} against "
+                   f"{value(runner_up):.1f} for {labels[runner_up]}, "
                    f"a margin of {margin:.1f} points. ")
-        if margin < NOISE_POINTS:
-            verdict += (f"That is **inside the ~{NOISE_POINTS:.0f}-point noise floor** at "
-                        f"{samples} samples per task — treat it as a tie and re-run "
-                        "with more samples before acting on it.")
+        scale = (f"~{floor:.1f} points at {samples} samples per task "
+                 f"(~{NOISE_POINTS:.0f} at {NOISE_SAMPLES}, scaled by 1/sqrt(n))")
+        if margin < floor:
+            verdict += (f"That is **inside the noise floor** of {scale} — treat it as "
+                        "a tie and re-run with more samples before acting on it.")
         else:
-            verdict += (f"That clears the ~{NOISE_POINTS:.0f}-point noise floor at "
-                        f"{samples} samples per task.")
+            verdict += f"That clears the noise floor of {scale}."
         out.append(verdict + "\n")
     return "\n".join(out)
 

--- a/benchkit/runner.py
+++ b/benchkit/runner.py
@@ -33,6 +33,12 @@ class Config:
     concurrency: int = 4
     test_timeout: int = 60
     temperature: float | None = None
+    # --- setup attribution: which *setup* produced this run, not just which
+    # model. A ranked cross-setup table needs something to key on, and a result
+    # file that does not name its serving config and harness cannot be ranked
+    # against one that used a different pair (issue #57).
+    serving_config: str = ""   # configs/<name>.sh active during the run
+    harness: str = ""          # harness name, or "" for benchkit's own loop
     extra: dict = field(default_factory=dict)
 
     @classmethod

--- a/benchkit/serving.py
+++ b/benchkit/serving.py
@@ -15,6 +15,7 @@ LAUNCHER = os.path.join(HERE, "start-qwen.sh")
 UNIT = "vllm-qwen"
 HEALTH_URL = "http://127.0.0.1:8801/v1/models"
 MODEL_RE = re.compile(r'^MODEL_ID="([^"]+)"', re.M)
+UNIT_RE = re.compile(r'^NAME="([^"$]+)"', re.M)
 
 
 def current_model(launcher=LAUNCHER):
@@ -75,3 +76,43 @@ def apply_config(name, configs=CONFIGS, launcher=LAUNCHER):
     os.chmod(launcher, 0o755)
     m = MODEL_RE.search(src)
     return path, (m.group(1) if m else None)
+
+
+def unit_of(src):
+    """The systemd unit a recipe declares via NAME=, or None if it is dynamic."""
+    m = UNIT_RE.search(src)
+    return m.group(1) if m else None
+
+
+def sweepable(src, unit=UNIT):
+    """(ok, reason) — can `bench sweep` install this recipe and restart it?
+
+    Two conditions, both mechanical. The recipe must carry a literal
+    `MODEL_ID="..."` line, because that is the only thing MODEL_RE can read and
+    report; and it must declare the same systemd unit this module restarts,
+    because installing a recipe for a different engine or a different backend
+    and then restarting `vllm-qwen` would leave the endpoint serving something
+    nobody asked for. configs/ deliberately holds recipes that fail both -- a
+    llama.cpp benchmark script, an env-tunable standalone server, a secondary
+    gemma backend on its own port. They are good recipes; they are just not
+    drivable from here, and naming one is a user error, not a crash.
+    """
+    if not MODEL_RE.search(src):
+        return False, 'no literal MODEL_ID="..." line — not a vLLM recipe this can drive'
+    declared = unit_of(src)
+    if declared is None:
+        return False, 'no literal NAME="..." unit — the launcher target is dynamic'
+    if declared != unit:
+        return False, f"runs as {declared!r}, not the {unit!r} unit this sweep restarts"
+    return True, ""
+
+
+def sweepable_configs(configs=CONFIGS, unit=UNIT):
+    """([(name, model_id, path), ...], [(name, reason), ...]) — usable, skipped."""
+    ok, skipped = [], []
+    for name, model_id, path in list_configs(configs):
+        with open(path) as f:
+            good, reason = sweepable(f.read(), unit=unit)
+        (ok if good else skipped).append(
+            (name, model_id, path) if good else (name, reason))
+    return ok, skipped

--- a/benchkit/serving.py
+++ b/benchkit/serving.py
@@ -108,11 +108,18 @@ def sweepable(src, unit=UNIT):
 
 
 def sweepable_configs(configs=CONFIGS, unit=UNIT):
-    """([(name, model_id, path), ...], [(name, reason), ...]) — usable, skipped."""
+    """([(name, model_id, path), ...], [(name, model_id, reason), ...]).
+
+    A skipped recipe keeps its model id: it is still a known-good config that
+    `bench configs` must list in full, just not one this module can install and
+    restart.
+    """
     ok, skipped = [], []
     for name, model_id, path in list_configs(configs):
         with open(path) as f:
             good, reason = sweepable(f.read(), unit=unit)
-        (ok if good else skipped).append(
-            (name, model_id, path) if good else (name, reason))
+        if good:
+            ok.append((name, model_id, path))
+        else:
+            skipped.append((name, model_id, reason))
     return ok, skipped

--- a/benchkit/sweep.py
+++ b/benchkit/sweep.py
@@ -187,9 +187,13 @@ def plan(setups, default_model=""):
     lines = []
     groups = group_by_config(setups)
     swaps = [c for c, _ in groups if c]
+    restarts = f"{_n(len(swaps), 'endpoint restart')}"
+    if swaps:
+        restarts += (f", plus one more to restore the original serving config"
+                     f" — {len(swaps) + 1} in total")
     lines.append(f"{_n(len(setups), 'setup')} in "
                  f"{_n(len(groups), 'serving-config group')} "
-                 f"({_n(len(swaps), 'endpoint restart')})")
+                 f"({restarts})")
     for cname, group in groups:
         lines.append(f"\n  serving config: {cname or '(active launcher, no swap)'}")
         for s in group:
@@ -217,6 +221,10 @@ def approve_restart(configs, assume_yes=False, stdin=None, stdout=None, log=prin
     approval*. Default is to refuse -- a non-interactive sweep that was not
     given `--yes-restart-endpoint` stops before it writes a single byte to the
     launcher, rather than treating silence as consent.
+
+    The number quoted to the operator is the *true* total: one restart per
+    distinct config to install it, plus one final restart to put the original
+    serving config back (see `_restore`) -- `len(configs) + 1`.
     """
     import sys
     if not configs:
@@ -229,15 +237,19 @@ def approve_restart(configs, assume_yes=False, stdin=None, stdout=None, log=prin
     stdout = sys.stdout if stdout is None else stdout
     if not (hasattr(stdin, "isatty") and stdin.isatty()):
         raise SystemExit(
-            f"this sweep would restart the shared serving endpoint {len(configs)} "
-            f"time(s) to install: {plan_txt}\n"
+            f"this sweep would restart the shared serving endpoint "
+            f"{len(configs) + 1} time(s): {len(configs)} to install "
+            f"{plan_txt}, and one more to restore the original serving config "
+            f"afterwards.\n"
             "Restarting a shared endpoint needs explicit human approval, and this "
             "session is not interactive.\n"
             "Re-run with --yes-restart-endpoint once the endpoint is genuinely "
             "yours to restart, or drop config= from every --setup to sweep only "
             "the harness and thinking axes against whatever is already serving.")
-    print(f"\nThis sweep will restart the shared serving endpoint {len(configs)} "
-          f"time(s), installing: {plan_txt}", file=stdout)
+    print(f"\nThis sweep will restart the shared serving endpoint "
+          f"{len(configs) + 1} time(s): {len(configs)} to install {plan_txt}, "
+          f"and one more to restore the original serving config afterwards.",
+          file=stdout)
     print("Anyone else using the endpoint will lose it for several minutes per "
           "restart.", file=stdout)
     print(f"Type {APPROVAL_WORD!r} to approve, anything else to abort: ",
@@ -293,6 +305,9 @@ def _restore(snapshot, serving, restart, log, swallow):
 def run_sweep(setups, outdir, execute, serving, assume_yes=False, restart=True,
               stdin=None, stdout=None, log=print, default_model=""):
     """Execute every setup, one endpoint restart per distinct serving config.
+
+    Plus one final restart to reinstate the original serving config, so a sweep
+    over N distinct configs costs the shared endpoint N+1 restarts.
 
     `execute(setup, label)` runs one row and returns `(summary, results)`; the
     caller owns how a row is run so this function stays testable without an

--- a/benchkit/sweep.py
+++ b/benchkit/sweep.py
@@ -119,14 +119,19 @@ def parse_setups(specs, known_harnesses=(), default_model=""):
             if s.harness and s.harness not in known_harnesses:
                 raise SystemExit(f"unknown harness {s.harness!r} in --setup; have: "
                                  + ", ".join(known_harnesses))
-    seen = {}
+    seen_keys, seen_slugs = set(), set()
     for s in setups:
         key = (s.config, s.harness, s.model, s.thinking)
         label = s.resolved_label(default_model)
-        if key in seen or label in seen.values():
+        # dedupe on the *slug*, because that is what becomes the filename: two
+        # labels that differ only in punctuation would otherwise collide hours
+        # into a sweep, after a restart nobody can take back.
+        slug = _slug(label)
+        if key in seen_keys or slug in seen_slugs:
             raise SystemExit(f"duplicate setup {label!r}: two rows of a sweep would "
                              "write the same result file. Give one of them label=...")
-        seen[key] = label
+        seen_keys.add(key)
+        seen_slugs.add(slug)
     return setups
 
 
@@ -162,7 +167,7 @@ def check_sweepable(setups, serving):
     """
     ok, skipped = serving.sweepable_configs()
     names = {n for n, _, _ in ok}
-    reasons = dict(skipped)
+    reasons = {n: why for n, _, why in skipped}
     bad = []
     for c in configs_needing_swap(setups):
         if c in names:
@@ -281,12 +286,25 @@ def run_sweep(setups, outdir, execute, serving, assume_yes=False, restart=True,
     `execute(setup, label)` runs one row and returns `(summary, results)`; the
     caller owns how a row is run so this function stays testable without an
     endpoint. Returns the list of result files written, in run order.
+
+    `restart=False` is only meaningful for a matrix that swaps no config at all
+    -- see the guard below.
     """
     import json
 
     check_sweepable(setups, serving)
     groups = group_by_config(setups)
     swaps = [c for c, _ in groups if c]
+    if swaps and not restart:
+        # Installing a recipe without restarting leaves the endpoint serving the
+        # *previous* config while every result file claims the new one. Those
+        # files would then be indelible: results/ is append-only.
+        raise SystemExit(
+            "a setup naming config= cannot run without restarting the endpoint: "
+            "the launcher would change but the endpoint would keep serving the "
+            "previous config, and every result file would name the wrong one.\n"
+            "Use --dry-run to rehearse the matrix, or drop config= to measure "
+            "whatever is already serving.")
     approve_restart(swaps, assume_yes=assume_yes, stdin=stdin, stdout=stdout, log=log)
 
     os.makedirs(outdir, exist_ok=True)

--- a/benchkit/sweep.py
+++ b/benchkit/sweep.py
@@ -182,8 +182,9 @@ def plan(setups, default_model=""):
     lines = []
     groups = group_by_config(setups)
     swaps = [c for c, _ in groups if c]
-    lines.append(f"{len(setups)} setups in {len(groups)} serving-config groups "
-                 f"({len(swaps)} endpoint restarts)")
+    lines.append(f"{_n(len(setups), 'setup')} in "
+                 f"{_n(len(groups), 'serving-config group')} "
+                 f"({_n(len(swaps), 'endpoint restart')})")
     for cname, group in groups:
         lines.append(f"\n  serving config: {cname or '(active launcher, no swap)'}")
         for s in group:
@@ -323,6 +324,10 @@ def run_sweep(setups, outdir, execute, serving, assume_yes=False, restart=True,
         log("\nrestoring the original serving config")
         _restore(snapshot, serving, restart, log, swallow=False)
     return paths
+
+
+def _n(count, noun):
+    return f"{count} {noun}" + ("" if count == 1 else "s")
 
 
 def _slug(s):

--- a/benchkit/sweep.py
+++ b/benchkit/sweep.py
@@ -1,0 +1,329 @@
+"""Sweep an explicit matrix of setups — serving config x harness x thinking mode.
+
+A "setup" on this machine is three things at once: which serving recipe the
+endpoint runs, which harness wraps the model, and whether thinking is on. Only
+the model axis was ever automated (`bench compare`), so a "best setup" verdict
+was measuring one axis of three (issue #57).
+
+Three deliberate choices shape this module.
+
+**The matrix is explicit, never a cross-product.** Independent `--configs` and
+`--harnesses` flags would multiply into combinations that cannot exist -- a
+llama.cpp recipe driven by the vLLM systemd unit, a harness pointed at a model
+its provider does not serve. Each `--setup` names one real combination.
+
+**Iteration is grouped by serving config.** Engine init costs minutes, so the
+endpoint is swapped once per distinct config and every setup that needs that
+config runs while it is up -- not once per combination.
+
+**Every swap is gated and every swap is undone.** Restarting a shared endpoint
+needs explicit human approval (CLAUDE.md), so an un-approved sweep refuses to
+start rather than asking forgiveness; and the launcher that was active when the
+sweep began is put back on the way out, on success *and* on failure, without the
+restore ever masking the exception that caused the failure (issue #37).
+"""
+import os
+from dataclasses import dataclass, replace
+
+#: label for runs that use benchkit's own tool-calling loop rather than a harness
+BUILTIN = "built-in loop"
+
+#: what the operator must type to approve restarting a shared endpoint
+APPROVAL_WORD = "yes"
+
+_KEYS = ("config", "harness", "model", "thinking", "label")
+_TRUE = ("on", "1", "true", "yes", "y")
+_FALSE = ("off", "0", "false", "no", "n")
+
+
+@dataclass(frozen=True)
+class Setup:
+    """One row of the sweep: a serving config, a harness, a model, a mode."""
+
+    config: str = ""    # serving-config name; "" means "whatever is running now"
+    harness: str = ""   # harness name; "" means benchkit's built-in loop
+    model: str = ""     # model spec for the harness, or the served alias
+    thinking: bool = False
+    label: str = ""
+
+    @property
+    def harness_name(self):
+        return self.harness or BUILTIN
+
+    @property
+    def config_name(self):
+        return self.config or "(active launcher)"
+
+    def resolved_label(self, default_model=""):
+        if self.label:
+            return self.label
+        model = (self.model or default_model or "?").split("/")[-1]
+        return (f"{self.config or 'active'} {self.harness or 'builtin'} "
+                f"{model} think-{'ON' if self.thinking else 'OFF'}")
+
+
+def parse_setup(text):
+    """`config=a,harness=opencode,model=x,thinking=both` -> [Setup, ...].
+
+    `thinking=both` expands to two setups because thinking and non-thinking are
+    different products and must never be collapsed into one row.
+    """
+    fields, thinking = {}, [False]
+    for part in str(text).split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if "=" not in part:
+            raise SystemExit(
+                f"bad --setup field {part!r}: expected key=value with keys "
+                + ", ".join(_KEYS))
+        key, _, value = part.partition("=")
+        key, value = key.strip().lower(), value.strip()
+        if key not in _KEYS:
+            raise SystemExit(f"unknown --setup key {key!r}; have: " + ", ".join(_KEYS))
+        if key in fields:
+            raise SystemExit(f"--setup key {key!r} given twice in {text!r}")
+        if key == "thinking":
+            low = value.lower()
+            if low == "both":
+                thinking = [False, True]
+            elif low in _TRUE:
+                thinking = [True]
+            elif low in _FALSE:
+                thinking = [False]
+            else:
+                raise SystemExit(
+                    f"bad thinking={value!r}; use on, off or both")
+            fields[key] = value
+        else:
+            fields[key] = value
+    base = Setup(config=fields.get("config", ""), harness=fields.get("harness", ""),
+                 model=fields.get("model", ""), label=fields.get("label", ""))
+    if len(thinking) > 1 and base.label:
+        # one label cannot name two products
+        return [replace(base, thinking=t, label=f"{base.label} think-{'ON' if t else 'OFF'}")
+                for t in thinking]
+    return [replace(base, thinking=t) for t in thinking]
+
+
+def parse_setups(specs, known_harnesses=(), default_model=""):
+    """Parse every --setup, validate harness names, and reject duplicate rows."""
+    setups = []
+    for spec in specs or []:
+        setups.extend(parse_setup(spec))
+    if not setups:
+        raise SystemExit("a sweep needs at least one --setup "
+                         "(e.g. --setup config=qwen3.6-35b-a3b-nvfp4,thinking=both)")
+    if known_harnesses:
+        for s in setups:
+            if s.harness and s.harness not in known_harnesses:
+                raise SystemExit(f"unknown harness {s.harness!r} in --setup; have: "
+                                 + ", ".join(known_harnesses))
+    seen = {}
+    for s in setups:
+        key = (s.config, s.harness, s.model, s.thinking)
+        label = s.resolved_label(default_model)
+        if key in seen or label in seen.values():
+            raise SystemExit(f"duplicate setup {label!r}: two rows of a sweep would "
+                             "write the same result file. Give one of them label=...")
+        seen[key] = label
+    return setups
+
+
+def group_by_config(setups):
+    """[(config_name, [setup, ...]), ...] -- one group per *distinct* config.
+
+    First-appearance order is preserved so the operator can read the restart
+    plan off their own command line. The grouping is what keeps a six-setup
+    sweep down to one endpoint restart per config instead of six.
+    """
+    order, groups = [], {}
+    for s in setups:
+        if s.config not in groups:
+            groups[s.config] = []
+            order.append(s.config)
+        groups[s.config].append(s)
+    return [(c, groups[c]) for c in order]
+
+
+def configs_needing_swap(setups):
+    """Distinct serving configs this sweep would install, in visit order."""
+    return [c for c, _ in group_by_config(setups) if c]
+
+
+def check_sweepable(setups, serving):
+    """Fail early, and by name, on setups naming a config the sweep cannot drive.
+
+    `configs/` holds recipes for other engines and other units (llama.cpp, the
+    secondary gemma backend, the env-tunable standalone server). They are
+    perfectly good recipes; they are simply not drivable by the vLLM systemd
+    machinery this sweep restarts, so naming one is a user error reported
+    before anything is touched -- never a crash halfway through.
+    """
+    ok, skipped = serving.sweepable_configs()
+    names = {n for n, _, _ in ok}
+    reasons = dict(skipped)
+    bad = []
+    for c in configs_needing_swap(setups):
+        if c in names:
+            continue
+        why = reasons.get(c) or "no such config"
+        bad.append(f"  {c}: {why}")
+    if bad:
+        raise SystemExit(
+            "these setups name serving configs this sweep cannot drive:\n"
+            + "\n".join(bad)
+            + "\n\nsweepable configs: " + (", ".join(sorted(names)) or "(none)")
+            + "\nRun `bench configs` for the full list and each skip reason.")
+
+
+def plan(setups, default_model=""):
+    """Human-readable dry-run text: what would run, and what would restart."""
+    lines = []
+    groups = group_by_config(setups)
+    swaps = [c for c, _ in groups if c]
+    lines.append(f"{len(setups)} setups in {len(groups)} serving-config groups "
+                 f"({len(swaps)} endpoint restarts)")
+    for cname, group in groups:
+        lines.append(f"\n  serving config: {cname or '(active launcher, no swap)'}")
+        for s in group:
+            lines.append(f"    - {s.resolved_label(default_model)}"
+                         f"   [harness={s.harness_name}"
+                         f" thinking={'ON' if s.thinking else 'OFF'}]")
+    return "\n".join(lines)
+
+
+def approve_restart(configs, assume_yes=False, stdin=None, stdout=None, log=print):
+    """Gate every endpoint restart behind an explicit, recorded approval.
+
+    CLAUDE.md: *never restart a shared serving endpoint without explicit human
+    approval*. Default is to refuse -- a non-interactive sweep that was not
+    given `--yes-restart-endpoint` stops before it writes a single byte to the
+    launcher, rather than treating silence as consent.
+    """
+    import sys
+    if not configs:
+        return True
+    plan_txt = ", ".join(configs)
+    if assume_yes:
+        log(f"restart approved by --yes-restart-endpoint: {plan_txt}")
+        return True
+    stdin = sys.stdin if stdin is None else stdin
+    stdout = sys.stdout if stdout is None else stdout
+    if not (hasattr(stdin, "isatty") and stdin.isatty()):
+        raise SystemExit(
+            f"this sweep would restart the shared serving endpoint {len(configs)} "
+            f"time(s) to install: {plan_txt}\n"
+            "Restarting a shared endpoint needs explicit human approval, and this "
+            "session is not interactive.\n"
+            "Re-run with --yes-restart-endpoint once the endpoint is genuinely "
+            "yours to restart, or drop config= from every --setup to sweep only "
+            "the harness and thinking axes against whatever is already serving.")
+    print(f"\nThis sweep will restart the shared serving endpoint {len(configs)} "
+          f"time(s), installing: {plan_txt}", file=stdout)
+    print("Anyone else using the endpoint will lose it for several minutes per "
+          "restart.", file=stdout)
+    print(f"Type {APPROVAL_WORD!r} to approve, anything else to abort: ",
+          end="", file=stdout)
+    stdout.flush()
+    answer = (stdin.readline() or "").strip().lower()
+    if answer != APPROVAL_WORD:
+        raise SystemExit("endpoint restart not approved — nothing was changed.")
+    log(f"restart approved interactively: {plan_txt}")
+    return True
+
+
+def snapshot_launcher(serving):
+    """Remember the active launcher verbatim so it can be put back byte-for-byte."""
+    with open(serving.LAUNCHER, "rb") as f:
+        return f.read()
+
+
+def restore_launcher(snapshot, serving):
+    """Rewrite the launcher from the snapshot. True if it actually changed."""
+    if snapshot is None:
+        return False
+    with open(serving.LAUNCHER, "rb") as f:
+        if f.read() == snapshot:
+            return False
+    with open(serving.LAUNCHER, "wb") as f:
+        f.write(snapshot)
+    os.chmod(serving.LAUNCHER, 0o755)
+    return True
+
+
+def _restore(snapshot, serving, restart, log, swallow):
+    """Put the original config back. `swallow` protects an in-flight exception.
+
+    On the failure path the restore must never replace the exception the
+    operator actually needs to read (issue #37), so it degrades to a loud
+    warning instead of raising.
+    """
+    try:
+        if restore_launcher(snapshot, serving) and restart:
+            log("restarting the endpoint on the original serving config...")
+            serving.restart()
+    except BaseException as exc:  # noqa: BLE001 — see docstring
+        if not swallow:
+            raise
+        log(f"WARNING: could not restore the original serving config: {exc!r}")
+        log("  the endpoint may still be running a sweep config — check "
+            "`bench configs` and restore it by hand.")
+        return False
+    return True
+
+
+def run_sweep(setups, outdir, execute, serving, assume_yes=False, restart=True,
+              stdin=None, stdout=None, log=print, default_model=""):
+    """Execute every setup, one endpoint restart per distinct serving config.
+
+    `execute(setup, label)` runs one row and returns `(summary, results)`; the
+    caller owns how a row is run so this function stays testable without an
+    endpoint. Returns the list of result files written, in run order.
+    """
+    import json
+
+    check_sweepable(setups, serving)
+    groups = group_by_config(setups)
+    swaps = [c for c, _ in groups if c]
+    approve_restart(swaps, assume_yes=assume_yes, stdin=stdin, stdout=stdout, log=log)
+
+    os.makedirs(outdir, exist_ok=True)
+    snapshot = snapshot_launcher(serving) if swaps else None
+    paths = []
+    try:
+        for cname, group in groups:
+            if cname:
+                log(f"\n=== installing serving config {cname} ===")
+                path, model_id = serving.apply_config(cname)
+                log(f"  {os.path.basename(path)} -> launcher, model {model_id}")
+                if restart:
+                    log("  restarting the service; engine init takes minutes...")
+                    serving.restart()
+            for s in group:
+                label = s.resolved_label(default_model)
+                log(f"\n--- {label} ---")
+                summary, results = execute(s, label)
+                p = os.path.join(outdir, _slug(label) + ".json")
+                if os.path.exists(p):
+                    # results/ is append-only; a colliding name is a bug, not a
+                    # licence to overwrite somebody's campaign.
+                    raise SystemExit(f"refusing to overwrite an existing result "
+                                     f"file: {p}")
+                with open(p, "w") as f:
+                    json.dump(dict(summary=summary, results=results), f, indent=2)
+                paths.append(p)
+                log(f"  -> written to {p}")
+    except BaseException:
+        if snapshot is not None:
+            log("\nsweep failed — restoring the original serving config")
+            _restore(snapshot, serving, restart, log, swallow=True)
+        raise
+    if snapshot is not None:
+        log("\nrestoring the original serving config")
+        _restore(snapshot, serving, restart, log, swallow=False)
+    return paths
+
+
+def _slug(s):
+    return "".join(c if c.isalnum() or c in "-_" else "-" for c in s.lower()).strip("-")

--- a/benchkit/sweep.py
+++ b/benchkit/sweep.py
@@ -199,6 +199,17 @@ def plan(setups, default_model=""):
     return "\n".join(lines)
 
 
+def result_paths(setups, outdir, default_model=""):
+    """Where every row of this matrix would write, in run order.
+
+    Exposed so a caller can check the whole matrix against an existing campaign
+    *before* the first restart: discovering a collision after an hour of runs
+    throws away work that cost a shared endpoint two restarts to produce.
+    """
+    return [os.path.join(outdir, _slug(s.resolved_label(default_model)) + ".json")
+            for s in setups]
+
+
 def approve_restart(configs, assume_yes=False, stdin=None, stdout=None, log=print):
     """Gate every endpoint restart behind an explicit, recorded approval.
 
@@ -325,8 +336,9 @@ def run_sweep(setups, outdir, execute, serving, assume_yes=False, restart=True,
                 summary, results = execute(s, label)
                 p = os.path.join(outdir, _slug(label) + ".json")
                 if os.path.exists(p):
-                    # results/ is append-only; a colliding name is a bug, not a
-                    # licence to overwrite somebody's campaign.
+                    # backstop: callers check the whole matrix up front (see
+                    # result_paths), but results/ is append-only, so a colliding
+                    # name is a bug, never a licence to overwrite a campaign.
                     raise SystemExit(f"refusing to overwrite an existing result "
                                      f"file: {p}")
                 with open(p, "w") as f:

--- a/configs/README.md
+++ b/configs/README.md
@@ -46,7 +46,7 @@ gets restarted). `bench configs` marks the rest and says why:
 | `qwen3.6-35b-a3b-nvfp4` | yes | — |
 | `ornith-1.5-35b-a3b-nvfp4` | yes | — |
 | `qwen3.8-27b-nvfp4-dspark` | yes | — |
-| `qwen3.8-27b-nvfp4-tunable` | no | Parameterised `MODEL=`, and runs as `qwen38-4bit` on port 8002 — a standalone server for sweeping `K`/`DRAFTER`/`SPEC` by hand, not a `vllm-qwen` recipe |
+| `qwen3.8-27b-nvfp4-tunable` | no | No `MODEL_ID=` line (it parameterises `MODEL=` instead) — the reason `bench configs` prints. It also runs as `qwen38-4bit` on port 8002, a standalone server for sweeping `K`/`DRAFTER`/`SPEC` by hand |
 | `gemma4-12b-w4a16` | no | Runs as `vllm-gemma` on port 8802 — a secondary backend, so restarting `vllm-qwen` would not serve it |
 | `llamacpp-qwen3.8-27b-bench` | no | llama.cpp, not vLLM, and no `MODEL_ID=` line at all |
 

--- a/configs/README.md
+++ b/configs/README.md
@@ -34,6 +34,25 @@ points, not gospel.
 "Measured" links to the campaign in [`../results/`](../results/) that produced it.
 Where a cell is blank, that config has not been put through the coding suite.
 
+## Which recipes `bench sweep` can drive
+
+`bench sweep` installs a recipe over `start-qwen.sh` and restarts the `vllm-qwen` systemd
+unit, so a recipe is sweepable only if it declares a literal `MODEL_ID="..."` (the one line
+`serving.py` can read back and report) **and** `NAME="vllm-qwen"` (the unit that actually
+gets restarted). `bench configs` marks the rest and says why:
+
+| Config | Sweepable | Why not |
+|---|---|---|
+| `qwen3.6-35b-a3b-nvfp4` | yes | — |
+| `ornith-1.5-35b-a3b-nvfp4` | yes | — |
+| `qwen3.8-27b-nvfp4-dspark` | yes | — |
+| `qwen3.8-27b-nvfp4-tunable` | no | Parameterised `MODEL=`, and runs as `qwen38-4bit` on port 8002 — a standalone server for sweeping `K`/`DRAFTER`/`SPEC` by hand, not a `vllm-qwen` recipe |
+| `gemma4-12b-w4a16` | no | Runs as `vllm-gemma` on port 8802 — a secondary backend, so restarting `vllm-qwen` would not serve it |
+| `llamacpp-qwen3.8-27b-bench` | no | llama.cpp, not vLLM, and no `MODEL_ID=` line at all |
+
+None of that makes them bad recipes. To make one sweepable, give it a literal
+`MODEL_ID="..."` and `NAME="vllm-qwen"` — that is all the sweep machinery reads.
+
 ## What makes these configs non-obvious
 
 - **MoE models need the `mia-vllm-gb10-linear-b12x` image** plus `--moe-backend` and

--- a/tests/test_pi_endpoint.py
+++ b/tests/test_pi_endpoint.py
@@ -220,6 +220,14 @@ class TestEndpointAvailability(PiEndpointCase):
 
     def setUp(self):
         super().setUp()
+        # The endpoint branch sits behind pi's own `--version` probe, so on a
+        # machine without pi installed (CI) every assertion below would only be
+        # measuring `pi not found on PATH`. Stub the probe so these tests test
+        # what they claim to: the endpoint logic.
+        from benchkit.harness import pi as pi_mod
+        original = pi_mod.PiHarness._version
+        pi_mod.PiHarness._version = lambda self: ("stub", None)
+        self.addCleanup(setattr, pi_mod.PiHarness, "_version", original)
         self.server = HTTPServer(("127.0.0.1", 0), _ModelsHandler)
         threading.Thread(target=self.server.serve_forever, daemon=True).start()
         self.addCleanup(self.server.server_close)

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -1,0 +1,431 @@
+"""Tests for `bench sweep` — the setup matrix, the restart gate, the restore.
+
+Nothing here touches a real endpoint or a real systemd unit. `serving` is
+replaced by a recorder that counts `apply_config`/`restart` calls against a
+temporary launcher file, both runners are stubbed, and results go to a temp
+dir — so the guardrail these tests pin (never restart a shared endpoint
+without explicit approval) is never violated by the tests themselves.
+"""
+import io
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from benchkit import report, sweep  # noqa: E402
+from benchkit import serving as real_serving  # noqa: E402
+
+SUMMARY = dict(
+    kind="agentic", pass_at_1=0.5, agent_score=0.4, mean_efficiency=0.8,
+    mean_tool_calls=6.0, mean_par_calls=5.0, mean_turns=7.0, by_task={},
+    by_difficulty={}, wall_seconds=1.0, mean_completion_tokens=10,
+    truncated=0, errored=0, valid_call_rate=1.0, malformed_args=0,
+    unknown_tools=0, hit_turn_limit=0, stalled_no_tool_call=0, generations=2,
+    tasks=1,
+)
+
+
+def _summary(label, *, config="", harness="", thinking=False, score=0.4,
+             samples=2):
+    s = dict(SUMMARY)
+    s["agent_score"] = score
+    s["config"] = dict(label=label, model="montimage-dgx-spark", thinking=thinking,
+                       max_tokens=0, samples=samples, concurrency=2,
+                       base_url="http://x/v1", serving_config=config,
+                       harness=harness)
+    return s
+
+
+class FakeServing:
+    """Records what a sweep *would* do to the endpoint, and does none of it."""
+
+    def __init__(self, tmp, sweepable=("cfg-a", "cfg-b"), fail_restore=False):
+        self.LAUNCHER = os.path.join(tmp, "start-qwen.sh")
+        with open(self.LAUNCHER, "w") as f:
+            f.write('MODEL_ID="original/model"\nNAME="vllm-qwen"\n')
+        self._sweepable = list(sweepable)
+        self.applied = []
+        self.restarts = 0
+        self.fail_restore = fail_restore
+
+    def sweepable_configs(self):
+        ok = [(n, f"org/{n}", f"/configs/{n}.sh") for n in self._sweepable]
+        return ok, [("llamacpp-qwen3.8-27b-bench", "not a vLLM recipe")]
+
+    def apply_config(self, name):
+        self.applied.append(name)
+        with open(self.LAUNCHER, "w") as f:
+            f.write(f'MODEL_ID="org/{name}"\nNAME="vllm-qwen"\n')
+        return f"/configs/{name}.sh", f"org/{name}"
+
+    def restart(self):
+        self.restarts += 1
+        if self.fail_restore and self.applied and self.restarts > len(self.applied):
+            raise RuntimeError("systemctl exploded during restore")
+        return True
+
+
+class ParseSetups(unittest.TestCase):
+    def test_thinking_both_expands_to_two_products(self):
+        got = sweep.parse_setup("config=cfg-a,thinking=both")
+        self.assertEqual([s.thinking for s in got], [False, True])
+        self.assertEqual({s.config for s in got}, {"cfg-a"})
+
+    def test_defaults_are_active_launcher_and_builtin_loop(self):
+        s, = sweep.parse_setup("model=foo")
+        self.assertEqual(s.config, "")
+        self.assertEqual(s.harness, "")
+        self.assertEqual(s.harness_name, sweep.BUILTIN)
+        self.assertEqual(s.config_name, "(active launcher)")
+
+    def test_unknown_key_is_a_user_error(self):
+        with self.assertRaises(SystemExit) as e:
+            sweep.parse_setup("cnofig=cfg-a")
+        self.assertIn("unknown --setup key", str(e.exception))
+
+    def test_field_without_equals_is_a_user_error(self):
+        with self.assertRaises(SystemExit):
+            sweep.parse_setup("cfg-a")
+
+    def test_bad_thinking_value_is_a_user_error(self):
+        with self.assertRaises(SystemExit):
+            sweep.parse_setup("thinking=maybe")
+
+    def test_unknown_harness_is_rejected_before_anything_runs(self):
+        with self.assertRaises(SystemExit) as e:
+            sweep.parse_setups(["harness=emacs"], known_harnesses=("pi", "opencode"))
+        self.assertIn("unknown harness", str(e.exception))
+
+    def test_empty_matrix_is_a_user_error(self):
+        with self.assertRaises(SystemExit):
+            sweep.parse_setups([])
+
+    def test_duplicate_rows_are_rejected_so_no_result_file_collides(self):
+        with self.assertRaises(SystemExit) as e:
+            sweep.parse_setups(["config=cfg-a", "config=cfg-a"])
+        self.assertIn("duplicate setup", str(e.exception))
+
+    def test_labelled_both_modes_keep_distinct_labels(self):
+        a, b = sweep.parse_setup("config=cfg-a,thinking=both,label=trial")
+        self.assertNotEqual(a.resolved_label(), b.resolved_label())
+
+
+class Grouping(unittest.TestCase):
+    def test_grouped_by_config_in_first_appearance_order(self):
+        setups = (sweep.parse_setup("config=cfg-b,thinking=both")
+                  + sweep.parse_setup("config=cfg-a")
+                  + sweep.parse_setup("config=cfg-b,harness=pi,model=m"))
+        groups = sweep.group_by_config(setups)
+        self.assertEqual([c for c, _ in groups], ["cfg-b", "cfg-a"])
+        self.assertEqual(len(groups[0][1]), 3)
+
+    def test_configs_needing_swap_skips_the_active_launcher_rows(self):
+        setups = sweep.parse_setup("harness=pi,model=m") + sweep.parse_setup("config=cfg-a")
+        self.assertEqual(sweep.configs_needing_swap(setups), ["cfg-a"])
+
+
+class Sweepability(unittest.TestCase):
+    def test_llamacpp_recipe_is_excluded_with_a_reason_not_a_crash(self):
+        with open(os.path.join(real_serving.CONFIGS,
+                               "llamacpp-qwen3.8-27b-bench.sh")) as f:
+            ok, reason = real_serving.sweepable(f.read())
+        self.assertFalse(ok)
+        self.assertIn("MODEL_ID", reason)
+
+    def test_a_recipe_for_another_unit_is_excluded(self):
+        ok, reason = real_serving.sweepable('MODEL_ID="a/b"\nNAME="vllm-gemma"\n')
+        self.assertFalse(ok)
+        self.assertIn("vllm-gemma", reason)
+
+    def test_the_shipped_vllm_recipes_are_sweepable(self):
+        ok, skipped = real_serving.sweepable_configs()
+        names = {n for n, _, _ in ok}
+        self.assertIn("qwen3.6-35b-a3b-nvfp4", names)
+        self.assertIn("qwen3.8-27b-nvfp4-dspark", names)
+        self.assertIn("llamacpp-qwen3.8-27b-bench", dict(skipped))
+
+    def test_naming_an_undrivable_config_fails_before_any_restart(self):
+        tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmp)
+        srv = FakeServing(tmp)
+        setups = sweep.parse_setup("config=llamacpp-qwen3.8-27b-bench")
+        with self.assertRaises(SystemExit) as e:
+            sweep.check_sweepable(setups, srv)
+        self.assertIn("cannot drive", str(e.exception))
+        self.assertEqual(srv.restarts, 0)
+
+
+class ApprovalGate(unittest.TestCase):
+    """CLAUDE.md: never restart a shared serving endpoint without approval."""
+
+    def test_non_interactive_without_the_flag_refuses(self):
+        with self.assertRaises(SystemExit) as e:
+            sweep.approve_restart(["cfg-a"], assume_yes=False,
+                                  stdin=io.StringIO(""), stdout=io.StringIO())
+        self.assertIn("--yes-restart-endpoint", str(e.exception))
+
+    def test_explicit_flag_approves(self):
+        self.assertTrue(sweep.approve_restart(["cfg-a"], assume_yes=True,
+                                              log=lambda *a: None))
+
+    def test_no_config_swap_needs_no_approval(self):
+        self.assertTrue(sweep.approve_restart([], log=lambda *a: None))
+
+    def test_interactive_yes_approves_and_anything_else_aborts(self):
+        class Tty(io.StringIO):
+            def isatty(self):
+                return True
+
+        self.assertTrue(sweep.approve_restart(
+            ["cfg-a"], stdin=Tty("yes\n"), stdout=io.StringIO(), log=lambda *a: None))
+        with self.assertRaises(SystemExit):
+            sweep.approve_restart(["cfg-a"], stdin=Tty("y\n"),
+                                  stdout=io.StringIO(), log=lambda *a: None)
+
+    def test_a_refused_sweep_writes_nothing_and_restarts_nothing(self):
+        tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmp)
+        srv = FakeServing(tmp)
+        before = open(srv.LAUNCHER).read()
+        out = os.path.join(tmp, "results")
+        with self.assertRaises(SystemExit):
+            sweep.run_sweep(sweep.parse_setup("config=cfg-a"), out,
+                            execute=lambda s, label: (_summary(label), []),
+                            serving=srv, stdin=io.StringIO(""),
+                            stdout=io.StringIO(), log=lambda *a: None)
+        self.assertEqual(srv.applied, [])
+        self.assertEqual(srv.restarts, 0)
+        self.assertEqual(open(srv.LAUNCHER).read(), before)
+        self.assertFalse(os.path.exists(out) and os.listdir(out))
+
+
+class RunSweep(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp)
+        self.out = os.path.join(self.tmp, "results")
+        self.srv = FakeServing(self.tmp)
+        self.original = open(self.srv.LAUNCHER).read()
+
+    def _run(self, setups, **kw):
+        calls = []
+
+        def execute(setup, label):
+            calls.append(label)
+            return _summary(label, config=setup.config, harness=setup.harness,
+                            thinking=setup.thinking), []
+
+        kw.setdefault("assume_yes", True)
+        paths = sweep.run_sweep(setups, self.out, execute=execute,
+                                serving=self.srv, log=lambda *a: None, **kw)
+        return paths, calls
+
+    def test_one_restart_per_distinct_config_not_per_setup(self):
+        setups = (sweep.parse_setup("config=cfg-a,thinking=both")
+                  + sweep.parse_setup("config=cfg-b,thinking=both"))
+        paths, calls = self._run(setups)
+        self.assertEqual(len(calls), 4)
+        self.assertEqual(self.srv.applied, ["cfg-a", "cfg-b"])
+        # two swaps plus the single restore restart
+        self.assertEqual(self.srv.restarts, 3)
+        self.assertEqual(len(paths), 4)
+
+    def test_every_result_names_its_serving_config_and_harness(self):
+        setups = (sweep.parse_setup("config=cfg-a")
+                  + sweep.parse_setup("config=cfg-a,harness=opencode,model=m"))
+        paths, _ = self._run(setups)
+        seen = []
+        for p in paths:
+            with open(p) as f:
+                cfg = json.load(f)["summary"]["config"]
+            seen.append((cfg["serving_config"], cfg["harness"]))
+        self.assertEqual(seen, [("cfg-a", ""), ("cfg-a", "opencode")])
+
+    def test_original_launcher_is_restored_on_success(self):
+        self._run(sweep.parse_setup("config=cfg-a"))
+        self.assertEqual(open(self.srv.LAUNCHER).read(), self.original)
+
+    def test_original_launcher_is_restored_on_failure(self):
+        def boom(setup, label):
+            raise RuntimeError("the run itself failed")
+
+        with self.assertRaises(RuntimeError) as e:
+            sweep.run_sweep(sweep.parse_setup("config=cfg-a"), self.out,
+                            execute=boom, serving=self.srv, assume_yes=True,
+                            log=lambda *a: None)
+        # the *original* exception survives, unmasked by the restore
+        self.assertEqual(str(e.exception), "the run itself failed")
+        self.assertEqual(open(self.srv.LAUNCHER).read(), self.original)
+
+    def test_a_failing_restore_never_masks_the_original_exception(self):
+        srv = FakeServing(self.tmp, fail_restore=True)
+        logged = []
+
+        def boom(setup, label):
+            raise RuntimeError("the run itself failed")
+
+        with self.assertRaises(RuntimeError) as e:
+            sweep.run_sweep(sweep.parse_setup("config=cfg-a"), self.out,
+                            execute=boom, serving=srv, assume_yes=True,
+                            log=logged.append)
+        self.assertEqual(str(e.exception), "the run itself failed")
+        self.assertTrue(any("could not restore" in line for line in logged))
+
+    def test_a_failing_restore_on_the_success_path_is_reported(self):
+        srv = FakeServing(self.tmp, fail_restore=True)
+        with self.assertRaises(RuntimeError) as e:
+            sweep.run_sweep(sweep.parse_setup("config=cfg-a"), self.out,
+                            execute=lambda s, label: (_summary(label), []),
+                            serving=srv, assume_yes=True, log=lambda *a: None)
+        self.assertIn("systemctl exploded", str(e.exception))
+
+    def test_no_config_in_the_matrix_means_no_swap_and_no_restore(self):
+        paths, calls = self._run(sweep.parse_setup("harness=opencode,model=m"),
+                                 assume_yes=False)
+        self.assertEqual(self.srv.applied, [])
+        self.assertEqual(self.srv.restarts, 0)
+        self.assertEqual(len(paths), 1)
+
+    def test_results_are_append_only_never_overwritten(self):
+        os.makedirs(self.out, exist_ok=True)
+        setups = sweep.parse_setup("config=cfg-a,label=fixed")
+        taken = os.path.join(self.out, sweep._slug(setups[0].resolved_label()) + ".json")
+        with open(taken, "w") as f:
+            f.write("{}")
+        with self.assertRaises(SystemExit) as e:
+            self._run(setups)
+        self.assertIn("refusing to overwrite", str(e.exception))
+        with open(taken) as f:
+            self.assertEqual(f.read(), "{}")
+
+
+class RankedReport(unittest.TestCase):
+    def _runs(self, *specs):
+        return [{"summary": _summary(label, config=cfg, harness=h,
+                                     thinking=t, score=score),
+                 "_path": f"{label}.json"}
+                for label, cfg, h, t, score in specs]
+
+    def test_ranks_within_a_harness_and_never_across_harnesses(self):
+        runs = self._runs(("a", "cfg-a", "", False, 0.40),
+                          ("b", "cfg-b", "", False, 0.62),
+                          ("c", "cfg-a", "opencode", False, 0.79))
+        md = report.rank_setups(runs, ["a", "b", "c"])
+        self.assertIn("### built-in loop · thinking OFF", md)
+        self.assertIn("### opencode · thinking OFF", md)
+        self.assertIn("no single cross-harness winner", md)
+        # the 79.0 opencode row must not be crowned over the built-in block
+        builtin = md.split("### built-in loop")[1].split("###")[0]
+        self.assertIn("Winner: b", builtin)
+
+    def test_thinking_modes_are_separate_blocks(self):
+        runs = self._runs(("off", "cfg-a", "", False, 0.4),
+                          ("on", "cfg-a", "", True, 0.9))
+        md = report.rank_setups(runs, ["off", "on"])
+        self.assertIn("thinking OFF", md)
+        self.assertIn("thinking ON", md)
+        self.assertIn("only setup in this block", md)
+
+    def test_a_margin_inside_the_noise_floor_is_called_a_tie(self):
+        runs = self._runs(("a", "cfg-a", "", False, 0.40),
+                          ("b", "cfg-b", "", False, 0.43))
+        md = report.rank_setups(runs, ["a", "b"])
+        self.assertIn("noise floor", md)
+        self.assertIn("treat it as a tie", md)
+
+    def test_a_margin_clearing_the_noise_floor_is_called_a_win(self):
+        runs = self._runs(("a", "cfg-a", "", False, 0.40),
+                          ("b", "cfg-b", "", False, 0.70))
+        md = report.rank_setups(runs, ["a", "b"])
+        self.assertIn("clears the ~8-point noise floor", md)
+
+    def test_every_row_names_its_serving_config_and_harness(self):
+        runs = self._runs(("a", "cfg-a", "opencode", False, 0.4))
+        md = report.rank_setups(runs, ["a"])
+        self.assertIn("`cfg-a`", md)
+        self.assertIn("opencode", md)
+
+    def test_build_embeds_the_ranking_when_asked(self):
+        runs = self._runs(("a", "cfg-a", "", False, 0.4),
+                          ("b", "cfg-b", "", False, 0.7))
+        md = report.build(runs, title="t", setups=True)
+        self.assertIn("## Ranked setups", md)
+        self.assertNotIn("## Ranked setups",
+                         report.build(runs, title="t"))
+
+
+class CliWiring(unittest.TestCase):
+    """The argparse surface and the per-setup Config attribution."""
+
+    def test_dry_run_prints_the_plan_and_touches_nothing(self):
+        from benchkit import cli
+        buf = io.StringIO()
+        old = sys.stdout
+        sys.stdout = buf
+        try:
+            rc = cli.main(["sweep", "--dry-run", "--suite", "agentic",
+                           "--setup", "config=qwen3.6-35b-a3b-nvfp4,thinking=both",
+                           "--setup", "config=qwen3.8-27b-nvfp4-dspark"])
+        finally:
+            sys.stdout = old
+        text = buf.getvalue()
+        self.assertEqual(rc, 0)
+        self.assertIn("3 setups in 2 serving-config groups", text)
+        self.assertIn("2 endpoint restarts", text)
+        self.assertIn("would ask for approval first", text)
+
+    def test_dry_run_rejects_an_undrivable_config(self):
+        from benchkit import cli
+        with self.assertRaises(SystemExit):
+            cli.main(["sweep", "--dry-run",
+                      "--setup", "config=llamacpp-qwen3.8-27b-bench"])
+
+    def test_builtin_setup_config_carries_the_attribution(self):
+        from benchkit import cli
+
+        captured = {}
+
+        def fake_execute(suite, tasks, cfg, max_turns=None, keep_code=False):
+            captured["cfg"] = cfg
+            return _summary(cfg.label), []
+
+        orig = cli._execute_suite
+        cli._execute_suite = fake_execute
+        try:
+            parsed = _Args(suite="agentic", base_url="http://x/v1",
+                           model="montimage-dgx-spark", samples=2, concurrency=2,
+                           test_timeout=60, max_tokens=6000, max_tokens_think=16000,
+                           max_turns=25, timeout=900, endpoint="")
+            setup, = sweep.parse_setup("config=cfg-a,thinking=on")
+            cli._sweep_execute(parsed, setup, "a label")
+        finally:
+            cli._execute_suite = orig
+        cfg = captured["cfg"]
+        self.assertEqual(cfg.serving_config, "cfg-a")
+        self.assertEqual(cfg.harness, "")
+        self.assertTrue(cfg.thinking)
+        self.assertEqual(cfg.max_tokens, 16000)
+        self.assertEqual(cfg.label, "a label")
+
+    def test_a_harness_setup_needs_an_agentic_suite(self):
+        from benchkit import cli
+        parsed = _Args(suite="core16", base_url="http://x/v1", model="m",
+                       samples=1, concurrency=1, test_timeout=60, max_tokens=1,
+                       max_tokens_think=1, max_turns=1, timeout=1, endpoint="")
+        setup, = sweep.parse_setup("harness=opencode,model=m")
+        with self.assertRaises(SystemExit) as e:
+            cli._sweep_execute(parsed, setup, "l")
+        self.assertIn("agentic suite", str(e.exception))
+
+
+class _Args:
+    def __init__(self, **kw):
+        self.__dict__.update(kw)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -387,6 +387,42 @@ class RankedReport(unittest.TestCase):
                          report.build(runs, title="t"))
 
 
+class LegacyAttribution(unittest.TestCase):
+    """Result files written before `bench sweep` must still rank honestly.
+
+    `harness.describe()` records the harness under the key "harness", not
+    "name". Reading the wrong key would file every pre-sweep harness run under
+    the built-in loop and rank three harnesses inside a single block — exactly
+    the cross-harness comparison the ranking exists to prevent.
+    """
+
+    def test_a_legacy_harness_block_is_read_and_kept_in_its_own_block(self):
+        runs = []
+        for name, score in (("opencode", 0.79), ("pi", 0.77), (None, 0.67)):
+            s = _summary(name or "benchkit loop", score=score)
+            s["config"].pop("harness")
+            s["config"].pop("serving_config")
+            if name:
+                s["harness"] = {"harness": name, "model": "m"}
+            runs.append({"summary": s, "_path": f"{name}.json"})
+        md = report.rank_setups(runs, ["opencode", "pi", "builtin"])
+        self.assertIn("### opencode · thinking OFF", md)
+        self.assertIn("### pi · thinking OFF", md)
+        self.assertIn(f"### {report.BUILTIN_HARNESS} · thinking OFF", md)
+        # every block holds exactly one run, so none can crown another harness
+        self.assertEqual(md.count("only setup in this block"), 3)
+
+    def test_a_missing_sample_count_never_renders_as_none(self):
+        runs = []
+        for label, score in (("a", 0.40), ("b", 0.80)):
+            s = _summary(label, score=score)
+            s["config"]["samples"] = None
+            runs.append({"summary": s, "_path": f"{label}.json"})
+        md = report.rank_setups(runs, ["a", "b"])
+        self.assertNotIn("None samples", md)
+        self.assertIn("did not record one", md)
+
+
 class NoRestartIsRefused(unittest.TestCase):
     """Swapping a config without restarting would file a lie in append-only results/."""
 
@@ -468,6 +504,62 @@ class CliWiring(unittest.TestCase):
         self.assertEqual(cfg.max_tokens, 16000)
         self.assertEqual(cfg.label, "a label")
 
+    def test_result_paths_are_known_before_the_first_restart(self):
+        setups = sweep.parse_setup("config=cfg-a,thinking=both")
+        paths = sweep.result_paths(setups, "/out", "m")
+        self.assertEqual(len(paths), 2)
+        self.assertTrue(all(p.startswith("/out/") and p.endswith(".json")
+                            for p in paths))
+        self.assertEqual(len(set(paths)), 2)
+
+    def test_a_colliding_result_file_is_caught_before_any_restart(self):
+        from benchkit import cli
+        tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmp)
+        setups = sweep.parse_setups(["config=qwen3.6-35b-a3b-nvfp4"],
+                                    default_model="montimage-dgx-spark")
+        outdir = os.path.join(tmp, f"{cli._stamp()}-half-finished")
+        os.makedirs(outdir)
+        victim, = sweep.result_paths(setups, outdir, "montimage-dgx-spark")
+        with open(victim, "w") as f:
+            f.write("an earlier campaign")
+        orig = cli.RESULTS
+        cli.RESULTS = tmp
+        try:
+            with self.assertRaises(SystemExit) as e:
+                cli.main(["sweep", "--title", "half finished",
+                          "--setup", "config=qwen3.6-35b-a3b-nvfp4"])
+        finally:
+            cli.RESULTS = orig
+        self.assertIn("earlier campaign", str(e.exception))
+        with open(victim) as f:
+            self.assertEqual(f.read(), "an earlier campaign")
+
+    def test_a_harness_setup_on_a_codegen_suite_fails_in_preflight(self):
+        """The wrong --suite must cost zero endpoint restarts, not two."""
+        from benchkit import cli
+        with self.assertRaises(SystemExit) as e:
+            cli.main(["sweep", "--suite", "core16",
+                      "--setup", "config=qwen3.6-35b-a3b-nvfp4,harness=opencode,"
+                                 "model=montimage-dgx-spark"])
+        self.assertIn("agentic suite", str(e.exception))
+
+    def test_report_can_rebuild_the_ranking_from_result_files(self):
+        from benchkit import cli
+        tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmp)
+        paths = []
+        for label, score in (("a", 0.4), ("b", 0.7)):
+            p = os.path.join(tmp, f"{label}.json")
+            with open(p, "w") as f:
+                json.dump(dict(summary=_summary(label, config="cfg-" + label,
+                                                score=score), results=[]), f)
+            paths.append(p)
+        out = os.path.join(tmp, "REPORT.md")
+        cli.main(["report", *paths, "--setups", "--out", out])
+        with open(out) as f:
+            self.assertIn("## Ranked setups", f.read())
+
     def test_a_bad_harness_model_spec_fails_before_any_restart(self):
         from benchkit import cli
         parsed = _Args(model="")
@@ -515,7 +607,8 @@ class CliWiring(unittest.TestCase):
                           "--setup", "config=qwen3.6-35b-a3b-nvfp4"])
         finally:
             cli.RESULTS = orig
-        self.assertIn("refusing to overwrite an existing report", str(e.exception))
+        self.assertIn("refusing to overwrite files from an earlier campaign",
+                      str(e.exception))
         with open(report_path) as f:
             self.assertEqual(f.read(), "first campaign")
 

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -54,7 +54,7 @@ class FakeServing:
 
     def sweepable_configs(self):
         ok = [(n, f"org/{n}", f"/configs/{n}.sh") for n in self._sweepable]
-        return ok, [("llamacpp-qwen3.8-27b-bench", "not a vLLM recipe")]
+        return ok, [("llamacpp-qwen3.8-27b-bench", "?", "not a vLLM recipe")]
 
     def apply_config(self, name):
         self.applied.append(name)
@@ -146,7 +146,9 @@ class Sweepability(unittest.TestCase):
         names = {n for n, _, _ in ok}
         self.assertIn("qwen3.6-35b-a3b-nvfp4", names)
         self.assertIn("qwen3.8-27b-nvfp4-dspark", names)
-        self.assertIn("llamacpp-qwen3.8-27b-bench", dict(skipped))
+        self.assertIn("llamacpp-qwen3.8-27b-bench", {n for n, _, _ in skipped})
+        # a skipped recipe keeps its model id so `bench configs` stays complete
+        self.assertEqual(len(skipped[0]), 3)
 
     def test_naming_an_undrivable_config_fails_before_any_restart(self):
         tmp = tempfile.mkdtemp()
@@ -190,7 +192,8 @@ class ApprovalGate(unittest.TestCase):
         tmp = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, tmp)
         srv = FakeServing(tmp)
-        before = open(srv.LAUNCHER).read()
+        with open(srv.LAUNCHER) as f:
+            before = f.read()
         out = os.path.join(tmp, "results")
         with self.assertRaises(SystemExit):
             sweep.run_sweep(sweep.parse_setup("config=cfg-a"), out,
@@ -199,7 +202,8 @@ class ApprovalGate(unittest.TestCase):
                             stdout=io.StringIO(), log=lambda *a: None)
         self.assertEqual(srv.applied, [])
         self.assertEqual(srv.restarts, 0)
-        self.assertEqual(open(srv.LAUNCHER).read(), before)
+        with open(srv.LAUNCHER) as f:
+            self.assertEqual(f.read(), before)
         self.assertFalse(os.path.exists(out) and os.listdir(out))
 
 
@@ -209,7 +213,8 @@ class RunSweep(unittest.TestCase):
         self.addCleanup(shutil.rmtree, self.tmp)
         self.out = os.path.join(self.tmp, "results")
         self.srv = FakeServing(self.tmp)
-        self.original = open(self.srv.LAUNCHER).read()
+        with open(self.srv.LAUNCHER) as f:
+            self.original = f.read()
 
     def _run(self, setups, **kw):
         calls = []
@@ -247,7 +252,8 @@ class RunSweep(unittest.TestCase):
 
     def test_original_launcher_is_restored_on_success(self):
         self._run(sweep.parse_setup("config=cfg-a"))
-        self.assertEqual(open(self.srv.LAUNCHER).read(), self.original)
+        with open(self.srv.LAUNCHER) as f:
+            self.assertEqual(f.read(), self.original)
 
     def test_original_launcher_is_restored_on_failure(self):
         def boom(setup, label):
@@ -259,7 +265,8 @@ class RunSweep(unittest.TestCase):
                             log=lambda *a: None)
         # the *original* exception survives, unmasked by the restore
         self.assertEqual(str(e.exception), "the run itself failed")
-        self.assertEqual(open(self.srv.LAUNCHER).read(), self.original)
+        with open(self.srv.LAUNCHER) as f:
+            self.assertEqual(f.read(), self.original)
 
     def test_a_failing_restore_never_masks_the_original_exception(self):
         srv = FakeServing(self.tmp, fail_restore=True)
@@ -341,7 +348,29 @@ class RankedReport(unittest.TestCase):
         runs = self._runs(("a", "cfg-a", "", False, 0.40),
                           ("b", "cfg-b", "", False, 0.70))
         md = report.rank_setups(runs, ["a", "b"])
-        self.assertIn("clears the ~8-point noise floor", md)
+        self.assertIn("clears the noise floor", md)
+        self.assertIn("~8.0 points at 2 samples per task", md)
+
+    def test_the_noise_floor_shrinks_with_the_sample_count(self):
+        self.assertEqual(report.noise_floor(2), report.NOISE_POINTS)
+        self.assertLess(report.noise_floor(8), report.NOISE_POINTS)
+        self.assertGreater(report.noise_floor(1), report.NOISE_POINTS)
+        # a result file with no recorded sample count falls back, never crashes
+        self.assertEqual(report.noise_floor(None), report.NOISE_POINTS)
+
+    def test_a_block_mixing_scored_and_unscored_runs_uses_one_ruler(self):
+        """A table must never rank on a metric its own cells do not show."""
+        runs = self._runs(("a", "cfg-a", "", False, 0.90),
+                          ("b", "cfg-b", "", False, 0.10))
+        runs[0]["summary"]["agent_score"] = None      # predates oracle-par
+        runs[0]["summary"]["pass_at_1"] = 0.10
+        runs[1]["summary"]["pass_at_1"] = 0.80
+        md = report.rank_setups(runs, ["a", "b"])
+        self.assertIn("| pass@1 |", md)
+        self.assertNotIn("Agent score", md)
+        # ranked on pass@1, so b wins and the quoted figures are pass@1 figures
+        self.assertIn("Winner: b", md)
+        self.assertIn("80.0 against 10.0", md)
 
     def test_every_row_names_its_serving_config_and_harness(self):
         runs = self._runs(("a", "cfg-a", "opencode", False, 0.4))
@@ -356,6 +385,34 @@ class RankedReport(unittest.TestCase):
         self.assertIn("## Ranked setups", md)
         self.assertNotIn("## Ranked setups",
                          report.build(runs, title="t"))
+
+
+class NoRestartIsRefused(unittest.TestCase):
+    """Swapping a config without restarting would file a lie in append-only results/."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp)
+        self.srv = FakeServing(self.tmp)
+
+    def test_a_config_swap_without_a_restart_is_refused(self):
+        with self.assertRaises(SystemExit) as e:
+            sweep.run_sweep(sweep.parse_setup("config=cfg-a"),
+                            os.path.join(self.tmp, "out"),
+                            execute=lambda s, label: (_summary(label), []),
+                            serving=self.srv, assume_yes=True, restart=False,
+                            log=lambda *a: None)
+        self.assertIn("cannot run without restarting", str(e.exception))
+        self.assertEqual(self.srv.applied, [])
+
+    def test_a_matrix_with_no_config_swap_needs_no_restart(self):
+        paths = sweep.run_sweep(sweep.parse_setup("harness=opencode,model=m"),
+                                os.path.join(self.tmp, "out"),
+                                execute=lambda s, label: (_summary(label), []),
+                                serving=self.srv, restart=False,
+                                log=lambda *a: None)
+        self.assertEqual(len(paths), 1)
+        self.assertEqual(self.srv.restarts, 0)
 
 
 class CliWiring(unittest.TestCase):
@@ -410,6 +467,57 @@ class CliWiring(unittest.TestCase):
         self.assertTrue(cfg.thinking)
         self.assertEqual(cfg.max_tokens, 16000)
         self.assertEqual(cfg.label, "a label")
+
+    def test_a_bad_harness_model_spec_fails_before_any_restart(self):
+        from benchkit import cli
+        parsed = _Args(model="")
+        setup, = sweep.parse_setup("config=cfg-a,harness=opencode")
+        with self.assertRaises(SystemExit) as e:
+            cli._sweep_model(parsed, setup)
+        self.assertIn("no model selected", str(e.exception))
+
+    def test_the_restart_flag_is_wired_through_to_run_sweep(self):
+        """An argparse dest typo on the guardrail flag must not pass CI."""
+        from benchkit import cli
+        from benchkit import sweep as sweep_mod
+        seen = {}
+
+        def fake_run_sweep(setups, outdir, **kw):
+            seen.update(kw)
+            raise SystemExit("stop here")
+
+        orig = sweep_mod.run_sweep
+        sweep_mod.run_sweep = fake_run_sweep
+        try:
+            with self.assertRaises(SystemExit):
+                cli.main(["sweep", "--suite", "agentic", "--yes-restart-endpoint",
+                          "--title", "wiring probe",
+                          "--setup", "config=qwen3.6-35b-a3b-nvfp4"])
+        finally:
+            sweep_mod.run_sweep = orig
+        self.assertIs(seen.get("assume_yes"), True)
+
+    def test_a_same_day_report_is_never_overwritten(self):
+        """_stamp() is day-granular, so two same-title sweeps share an outdir."""
+        from benchkit import cli
+        tmp = tempfile.mkdtemp()          # never the real results/, which is append-only
+        self.addCleanup(shutil.rmtree, tmp)
+        outdir = os.path.join(tmp, f"{cli._stamp()}-collision-probe")
+        os.makedirs(outdir)
+        report_path = os.path.join(outdir, "REPORT.md")
+        with open(report_path, "w") as f:
+            f.write("first campaign")
+        orig = cli.RESULTS
+        cli.RESULTS = tmp
+        try:
+            with self.assertRaises(SystemExit) as e:
+                cli.main(["sweep", "--title", "collision probe",
+                          "--setup", "config=qwen3.6-35b-a3b-nvfp4"])
+        finally:
+            cli.RESULTS = orig
+        self.assertIn("refusing to overwrite an existing report", str(e.exception))
+        with open(report_path) as f:
+            self.assertEqual(f.read(), "first campaign")
 
     def test_a_harness_setup_needs_an_agentic_suite(self):
         from benchkit import cli

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -170,6 +170,15 @@ class ApprovalGate(unittest.TestCase):
                                   stdin=io.StringIO(""), stdout=io.StringIO())
         self.assertIn("--yes-restart-endpoint", str(e.exception))
 
+    def test_refusal_counts_the_restore_restart_too(self):
+        """Two configs cost three restarts — the gate must not quote two."""
+        with self.assertRaises(SystemExit) as e:
+            sweep.approve_restart(["cfg-a", "cfg-b"], assume_yes=False,
+                                  stdin=io.StringIO(""), stdout=io.StringIO())
+        msg = str(e.exception)
+        self.assertIn("3 time(s)", msg)
+        self.assertIn("restore the original serving config", msg)
+
     def test_explicit_flag_approves(self):
         self.assertTrue(sweep.approve_restart(["cfg-a"], assume_yes=True,
                                               log=lambda *a: None))

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -378,6 +378,43 @@ class RankedReport(unittest.TestCase):
         self.assertIn("`cfg-a`", md)
         self.assertIn("opencode", md)
 
+    def test_no_cross_block_row_is_bolded_as_the_overall_winner(self):
+        """The Results table must not crown a harness above the section that
+        explains no cross-harness winner exists."""
+        runs = self._runs(("builtin-a", "cfg-a", "", False, 0.40),
+                          ("builtin-b", "cfg-b", "", False, 0.50),
+                          ("opencode-a", "cfg-a", "opencode", False, 0.90))
+        md = report.build(runs, title="t", setups=True)
+        results = md.split("## Results")[1].split("## Ranked setups")[0]
+        # one leader per block, so exactly two bolded rows, not one global best
+        self.assertIn("**builtin-b**", results)
+        self.assertIn("**opencode-a**", results)
+        self.assertNotIn("**builtin-a**", results)
+        self.assertIn("Bold marks the leader **within** its own harness", results)
+
+    def test_the_disagreement_table_never_pairs_two_blocks(self):
+        runs = self._runs(("builtin", "cfg-a", "", False, 0.40),
+                          ("opencode", "cfg-a", "opencode", False, 0.90))
+        for r, tasks in zip(runs, ({"t1": 1.0}, {"t1": 0.0})):
+            r["summary"]["by_task"] = tasks
+        md = report.build(runs, title="t", setups=True)
+        self.assertNotIn("Where they disagree", md)
+
+    def test_chart_labels_distinguish_setups_on_one_model(self):
+        runs = self._runs(("a", "cfg-a", "", False, 0.4),
+                          ("b", "cfg-b", "", False, 0.5),
+                          ("c", "cfg-a", "opencode", False, 0.6))
+        short = report._setup_short(runs)
+        self.assertEqual(len(set(short)), 3)
+
+    def test_the_noise_floor_follows_the_noisiest_row_in_the_block(self):
+        runs = self._runs(("a", "cfg-a", "", False, 0.40),
+                          ("b", "cfg-b", "", False, 0.50))
+        runs[0]["summary"]["config"]["samples"] = 8
+        runs[1]["summary"]["config"]["samples"] = 2
+        md = report.rank_setups(runs, ["a", "b"])
+        self.assertIn("at 2 samples per task", md)
+
     def test_build_embeds_the_ranking_when_asked(self):
         runs = self._runs(("a", "cfg-a", "", False, 0.4),
                           ("b", "cfg-b", "", False, 0.7))
@@ -420,7 +457,7 @@ class LegacyAttribution(unittest.TestCase):
             runs.append({"summary": s, "_path": f"{label}.json"})
         md = report.rank_setups(runs, ["a", "b"])
         self.assertNotIn("None samples", md)
-        self.assertIn("did not record one", md)
+        self.assertIn("assumed — not every run in this block recorded one", md)
 
 
 class NoRestartIsRefused(unittest.TestCase):
@@ -544,6 +581,25 @@ class CliWiring(unittest.TestCase):
                                  "model=montimage-dgx-spark"])
         self.assertIn("agentic suite", str(e.exception))
 
+    def test_report_refuses_to_overwrite_an_existing_report(self):
+        from benchkit import cli
+        tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmp)
+        src = os.path.join(tmp, "a.json")
+        with open(src, "w") as f:
+            json.dump(dict(summary=_summary("a"), results=[]), f)
+        out = os.path.join(tmp, "REPORT.md")
+        with open(out, "w") as f:
+            f.write("an earlier campaign")
+        with self.assertRaises(SystemExit) as e:
+            cli.main(["report", src])
+        self.assertIn("refusing to overwrite an existing report", str(e.exception))
+        with open(out) as f:
+            self.assertEqual(f.read(), "an earlier campaign")
+        cli.main(["report", src, "--force"])
+        with open(out) as f:
+            self.assertNotEqual(f.read(), "an earlier campaign")
+
     def test_report_can_rebuild_the_ranking_from_result_files(self):
         from benchkit import cli
         tmp = tempfile.mkdtemp()
@@ -569,25 +625,38 @@ class CliWiring(unittest.TestCase):
         self.assertIn("no model selected", str(e.exception))
 
     def test_the_restart_flag_is_wired_through_to_run_sweep(self):
-        """An argparse dest typo on the guardrail flag must not pass CI."""
+        """An argparse dest typo on the guardrail flag must not pass CI.
+
+        Belt and braces: `run_sweep` is stubbed *and* the real restart path is
+        stubbed, so even a refactor that moved the patch target could not turn
+        this test into a live `systemctl restart` in CI.
+        """
         from benchkit import cli
+        from benchkit import serving as real
         from benchkit import sweep as sweep_mod
-        seen = {}
+        seen, touched = {}, []
+        tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmp)
 
         def fake_run_sweep(setups, outdir, **kw):
             seen.update(kw)
             raise SystemExit("stop here")
 
-        orig = sweep_mod.run_sweep
+        saved = (sweep_mod.run_sweep, real.restart, real.apply_config, cli.RESULTS)
         sweep_mod.run_sweep = fake_run_sweep
+        real.restart = lambda *a, **k: touched.append("restart")
+        real.apply_config = lambda *a, **k: touched.append("apply")
+        cli.RESULTS = tmp
         try:
             with self.assertRaises(SystemExit):
                 cli.main(["sweep", "--suite", "agentic", "--yes-restart-endpoint",
                           "--title", "wiring probe",
                           "--setup", "config=qwen3.6-35b-a3b-nvfp4"])
         finally:
-            sweep_mod.run_sweep = orig
+            (sweep_mod.run_sweep, real.restart, real.apply_config,
+             cli.RESULTS) = saved
         self.assertIs(seen.get("assume_yes"), True)
+        self.assertEqual(touched, [])
 
     def test_a_same_day_report_is_never_overwritten(self):
         """_stamp() is day-granular, so two same-title sweeps share an outdir."""


### PR DESCRIPTION
Closes #57

## Summary

`bench compare` sweeps one axis — the Hugging Face model id. But a "setup" on this
machine is the serving config, the harness and the thinking mode together, so a
"best setup" verdict was measuring one axis of three. This adds `bench sweep`: an
explicit setup matrix, one endpoint restart per distinct serving config, behind an
approval gate that defaults to refusing, with one ranked report at the end.

## Approach

Analysis option 2 — a new subcommand over an explicit matrix — rather than
overloading `bench compare` (option 1) or introducing a declarative spec format
(option 3). Three design choices are load-bearing:

**The matrix is explicit, never a cross-product.** Independent `--configs` /
`--harnesses` flags would multiply into combinations that cannot exist: a llama.cpp
recipe driven by the vLLM systemd unit, a harness pointed at a model its provider
does not serve. Each `--setup config=…,harness=…,model=…,thinking=…` is one real
combination. `thinking=both` is the only expansion, because thinking and
non-thinking are two products, not one row.

**Iteration is grouped by serving config.** Engine init costs minutes, so setups are
grouped by config in first-appearance order and the endpoint is swapped once per
distinct config — a six-setup sweep over two configs restarts twice, not six times.

**Cross-harness scores are never ranked against each other.** This repo's own
harness-spread campaign records a swing on identical weights as large as a model
change, so the report ranks within one `(harness, thinking mode)` block and says so.
The Results table bolds each block's leader, the head-to-head table is restricted to
one block, and there is deliberately no global winner.

```bash
./bench sweep --suite agentic-hard --title "27B dense vs 35B MoE" --dry-run \
  --setup config=qwen3.6-35b-a3b-nvfp4,thinking=both \
  --setup config=qwen3.8-27b-nvfp4-dspark,thinking=both \
  --setup config=qwen3.6-35b-a3b-nvfp4,harness=opencode,model=montimage-dgx-spark
```

## Decision Record

**Root cause.** `cmd_compare` iterates only over model ids. The config axis existed
unused (`serving.list_configs`/`apply_config`) and the harness axis existed unused
(`harness/runner.py:run`), and `runner.Config` recorded neither the serving config
nor the harness — so nothing downstream could key a ranked cross-setup table.

**Options considered.** (1) Extend `cmd_compare` in place with `--configs`/
`--harnesses` — rejected: overloads a command whose contract users rely on, and
independent flags cross-product into invalid setups. (2) **New `bench sweep` over an
explicit matrix — selected.** (3) Declarative `--spec sweep.yaml` — rejected:
introduces a config-file format with no precedent in a repo whose dependency floor
is deliberately `openai`-only.

**Guardrails, by construction.** Issue #19 (the restart guardrail) is still open, so
the gate is implemented here rather than depended on: `approve_restart` refuses by
default, requires a typed `yes` on a tty, and refuses outright when it cannot ask.
Issue #37 (restore masking the original failure) is avoided by construction: the
restore degrades to a loud warning on the failure path so the exception the operator
needs to read survives. Issue #20 (append-only results) is honoured: every target
path is checked against an earlier campaign *before* the first restart.

**Residual risk / scope note.** `configs/` ships three sweepable recipes
(`qwen3.6-35b-a3b-nvfp4`, `ornith-1.5-35b-a3b-nvfp4`, `qwen3.8-27b-nvfp4-dspark`) and
three that cannot be driven by the `vllm-qwen` systemd machinery. The issue's
motivating pair (`-dspark` vs `-tunable`) is therefore not sweepable *as shipped*:
`-tunable` has no literal `MODEL_ID=` line and runs as `qwen38-4bit` on port 8002.
The mechanism supports any two same-weights recipes; making that specific pair
sweepable is a one-line change to the recipe, documented in `configs/README.md`.
Nothing in this PR was verified against a live endpoint — every test stubs
`serving.apply_config`/`restart`.

## Changes

| File | Change |
|---|---|
| `benchkit/sweep.py` | **New.** Setup parsing/expansion, grouping by config, the approval gate, launcher snapshot/restore, `run_sweep` |
| `benchkit/cli.py` | `cmd_sweep` + subparser; `_sweep_execute`/`_sweep_harness`/`_sweep_model` pre-flight; `bench configs` marks non-sweepable recipes; `bench report --setups`/`--force` |
| `benchkit/serving.py` | `unit_of`, `sweepable`, `sweepable_configs` — exclude recipes the vLLM systemd machinery cannot drive, with a reason |
| `benchkit/report.py` | `rank_setups`, `_blocks`, `_setup_short`, `noise_floor`; per-block bolding, per-block head-to-head, sweep-aware chart labels |
| `benchkit/runner.py` | `Config.serving_config` / `Config.harness` attribution |
| `tests/test_sweep.py` | **New.** 56 tests over the matrix, the gate, the restore and the ranking |
| `tests/__init__.py` | **New.** Lets `unittest discover -t .` work |
| `.github/workflows/ci.yml` | Run the unit tests in CI — they were never executed before |
| `tests/test_pi_endpoint.py` | Stub pi's `--version` probe: those four endpoint tests silently degraded to `pi not found on PATH` wherever pi is not installed, which the new CI step exposed |
| `README.md`, `AGENTS.md`, `CLAUDE.md`, `configs/README.md` | Command table, runbook step 6b, guardrail wording, sweepability table |

## Test Results

```
python3 -m unittest discover -s tests -t .   → Ran 124 tests … OK   (56 new)
python3 -m ruff check .                      → All checks passed
python3 -m mypy benchkit router.py           → Success: no issues found in 24 source files
./bench validate                             → 28/28 reference solutions pass
```

No test touches a live endpoint, a real `systemctl`, or `results/`. `serving` is
replaced by a recorder that counts `apply_config`/`restart` against a temp launcher;
the argparse-wiring test additionally stubs `serving.restart`/`apply_config` and
asserts they were never called, so no refactor can turn it into a live restart in CI.

Three autonomous review-fix cycles were run; 21 findings were raised and all were
fixed. The most consequential: `harness.describe()` records the harness under
`"harness"`, not `"name"` — reading the wrong key filed every pre-sweep harness run
under the built-in loop and ranked four harnesses inside one block, which is exactly
the cross-harness comparison the feature exists to prevent.

## Acceptance Criteria Verification

| # | Criterion | Status | Evidence |
|---|---|---|---|
| 1 | Two or more serving configs for the same weights compared in one command | ✅ | `--setup config=A` + `--setup config=B` in one `bench sweep`; grouped so each config is installed once. `test_one_restart_per_distinct_config_not_per_setup` |
| 2 | The sweep covers harnesses, and every score names its harness | ✅ | `harness=` on any setup; `Config.harness`/`serving_config` land in every result JSON, and every report row and block header names the harness. `test_every_result_names_its_serving_config_and_harness`, `test_a_legacy_harness_block_is_read_and_kept_in_its_own_block` |
| 3 | The report ranks setups, names a winner, states when the margin is noise | ✅ | `report.rank_setups` ranks per block, names each block's winner, and quotes `noise_floor(samples)` (~8 pts at `--samples 2`, scaled 1/√n, taken from the block's noisiest row). `test_a_margin_inside_the_noise_floor_is_called_a_tie` + 4 more |
| 4 | Endpoint restarts follow the shared-endpoint approval guardrail | ✅ | `approve_restart` refuses by default, demands a typed `yes` on a tty, refuses non-interactively without `--yes-restart-endpoint`; runs before `makedirs` and before any `apply_config`. `test_a_refused_sweep_writes_nothing_and_restarts_nothing` + 4 more |
| 5 | The original serving config is restored when the sweep ends, including on failure | ✅ | Byte-for-byte launcher snapshot restored on both paths; on failure the restore degrades to a warning so the original exception is not masked (#37). `test_original_launcher_is_restored_on_failure`, `test_a_failing_restore_never_masks_the_original_exception` |
