### PR TITLE
docs(readme): lead with the winning recipe, add architecture diagrams

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,8 +106,13 @@ Otherwise point `BENCH_BASE_URL` at each endpoint in turn and use `./bench run`.
 
 ```bash
 ./bench report results/<date>-<name>/*.json \
-  --title "..." --question "..." --verdict "..." --notes analysis.md
+  --title "..." --question "..." --verdict "..." \
+  --out results/<date>-<name>/REPORT-analysis.md
 ```
+
+`bench compare` already wrote a `REPORT.md` into that directory, and `bench report`
+refuses to overwrite an existing report — pass `--out` or `--force`. `--notes <file.md>`
+splices in your own written analysis; write that file first.
 
 The verdict must be a decision, not a summary. Judge on:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ Do not proceed until `/models` returns the model you intend to test.
 ## Step 1 — install and prove the tests
 
 ```bash
-pip install -r requirements.txt
+pip install -e .
 ./bench validate                  # must print 28/28
 ./bench validate --suite agentic-all   # must print 16/16
 ```
@@ -105,7 +105,7 @@ Otherwise point `BENCH_BASE_URL` at each endpoint in turn and use `./bench run`.
 ## Step 5 — decide, and write it down
 
 ```bash
-./bench report results/<date>-<name>/run-*.json \
+./bench report results/<date>-<name>/*.json \
   --title "..." --question "..." --verdict "..." --notes analysis.md
 ```
 
@@ -176,9 +176,13 @@ the secondary gemma backend). `bench configs` marks each one and says why; namin
 
 ## Step 7 — install the winner
 
+`bench configs` is safe on any machine. **`bench apply` requires the serving host** — it
+rewrites `start-qwen.sh`, and with `--restart` it takes the shared endpoint down for
+several minutes. Get human approval before running it.
+
 ```bash
-./bench configs
-./bench apply <config-name> --restart
+./bench configs                          # safe anywhere
+./bench apply <config-name> --restart    # serving host only; restarts vllm-qwen
 ```
 
 Then add a row to `configs/README.md` with the measured numbers. A config with no measured

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Critical commands
 
 ```bash
-pip install -r requirements.txt          # openai>=1.40
+pip install -e .                          # openai>=2, aiohttp
 ./bench validate                          # 28/28
 ./bench validate --suite agentic-all      # 16/16
 ./bench run --suite all --label "..."     # full evaluation
@@ -11,7 +11,7 @@ pip install -r requirements.txt          # openai>=1.40
 ./bench sweep --setup config=<c>,thinking=both --dry-run   # rank whole setups
 ./bench harness models                    # models your opencode/pi can reach
 ./bench harness run --harness opencode -m <p>/<m>   # benchmark one of them
-./bench apply <config> --restart          # install winner
+./bench apply <config> --restart          # install winner (serving host only)
 ```
 
 ## Toolchain floor

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ pip install -e .                          # openai>=2, aiohttp
 ## Toolchain floor
 
 - **Python ≥ 3.10** (router.py:70, benchkit/runner.py:35)
-- **Runtime**: `openai>=1.40` only; **endpoint**: any OpenAI-compatible server
+- **Runtime**: `openai>=2,<3` and `aiohttp>=3.8,<4` (pyproject.toml); **endpoint**: any OpenAI-compatible server
 
 ## Environment variables
 

--- a/README.md
+++ b/README.md
@@ -1,62 +1,19 @@
-# dgx-spark-llm-lab
+![license](https://img.shields.io/badge/license-MIT-blue)
+![python](https://img.shields.io/badge/python-3.10%2B-blue)
+![validate](https://img.shields.io/badge/validate-28%2F28-brightgreen)
+![reference hardware](https://img.shields.io/badge/reference%20hardware-DGX%20Spark%20GB10-76B900)
 
-**Find the best configuration for your daily-driver LLM — then keep it.**
+# Find the best LLM setup for your own machine
 
-Public benchmarks rank *models* on hardware you don't have, at settings you won't use.
-This one answers a narrower and more useful question: **of the things I could actually
-serve on this box, which exact configuration should I run every day?**
+Public leaderboards rank models on hardware you don't have, at settings you won't use.
+This runs the suites against your endpoint and ends in a config file you serve.
 
-The answer is machine-local, and that is the point. The best setup for user A is routinely
-the wrong one for user B — different GPU, different memory ceiling, different quantisation
-available, different concurrency, different work. A published score cannot know any of
-that. Running the suite on your own endpoint can.
+[**Best recipe now &rarr;**](#best-recipe-right-now) · [**Quick start &rarr;**](#quick-start) · [**Findings &rarr;**](#what-the-campaigns-found)
 
-A configuration is more than a model name — it's the model, the quantisation, the serving
-flags, and the thinking mode, together. Those interact: the same weights score 60.7 % or
-80.4 % on the same suite depending on one chat-template kwarg, and the right answer flips
-between one-shot coding and tool loops. A leaderboard cannot tell you that. Measuring on
-your own endpoint can.
+## Best recipe right now
 
-So the loop here is **benchmark → decide → install**, and it ends in a config file you
-serve, not a number you quote:
-
-- **Measured where it runs.** Any OpenAI-compatible endpoint, your hardware, your flags.
-- **Both thinking modes, always.** Reported as separate rows, because they are separate
-  products.
-- **Cost next to accuracy.** Output tokens, wall-clock, turns, truncation — a model that
-  wins by thinking for 16k tokens has not won.
-- **Two workload shapes.** One-shot code generation *and* multi-turn agentic tool calling,
-  because they disagree.
-- **Your harness and your models, not ours.** `bench harness models` lists what your
-  opencode or pi install can already reach; pick one and benchmark it. A model neither knows
-  about is reachable with `--endpoint <url>` on any of the three harnesses. Nothing is
-  written to your editor's configuration either way.
-- **Your harness, not ours.** The same model scores 12 points apart through four different
-  tool loops, so the suites also run through the coding agent you actually use (`pi`,
-  `opencode`, `claude-code`).
-- **The winner is installable.** `./bench apply <config> --restart` and you're serving it.
-- **Nothing scored on vibes.** Hidden executable unit tests and workspace predicates, each
-  proven passable by a reference solution before any model is judged.
-
-Built and used on an **NVIDIA DGX Spark (GB10)**, but the harness itself only needs a URL.
-
-```bash
-pip install -e .
-export BENCH_BASE_URL=http://localhost:8001/v1 BENCH_MODEL=my-model
-
-./bench validate                      # 44/44 — the tests are passable
-./bench run --suite all --thinking --max-tokens 16000 --label "my-model think-ON"
-./bench report results/*/run-*.json --title "My model" --verdict "..."
-```
-
-The last command writes a `REPORT.md` like
-[this one](results/2026-08-20-ornith-vs-qwen3.6/REPORT.md).
-
-## Current winner — `qwen3.6-35b-a3b-nvfp4`
-
-As of the 2026-08-20 round, the configuration to serve is **Qwen3.6-35B-A3B-NVFP4 on
-vLLM with thinking off**. It survived a head-to-head against Ornith-1.5-35B-A3B and tops
-every suite it has been run on.
+**Qwen3.6-35B-A3B-NVFP4 on vLLM, thinking off.** Won the 2026-08-20 round and tops every
+suite it has been run on.
 
 ```bash
 ./bench apply qwen3.6-35b-a3b-nvfp4 --restart
@@ -64,36 +21,121 @@ every suite it has been run on.
 
 | | |
 |---|---|
-| Model | `unsloth/Qwen3.6-35B-A3B-NVFP4` (MoE, ~3B active) |
-| Serving | vLLM, TP1, 262k ctx, fp8 KV cache, MTP speculative decoding (k=2), prefix caching |
-| Memory | `--gpu-memory-utilization 0.62` (~74 GB of the 119 GB unified pool) |
+| Weights | `unsloth/Qwen3.6-35B-A3B-NVFP4` — MoE, ~3B active |
+| Serving | vLLM TP1, 262k ctx, fp8 KV cache, MTP speculative decoding (k=2), prefix caching |
+| Memory | `--gpu-memory-utilization 0.62` — ~74 GB of the 119 GB unified pool |
 | Recipe | [`configs/qwen3.6-35b-a3b-nvfp4.sh`](configs/qwen3.6-35b-a3b-nvfp4.sh) |
-| `hard12` + `core16` | **82.1 % pass@1** thinking-on, 80.4 % thinking-off ([report](results/2026-08-20-ornith-vs-qwen3.6/REPORT.md)) |
-| `agentic` | **100 % solved**, 95–97 % valid tool calls, no malformed arguments ([report](results/2026-08-20-agentic-baseline/REPORT.md)) |
-| `agentic-hard` | **agent score 54.6** thinking-on (100 % solved x 54.6 % efficiency), 50.1 thinking-off ([report](results/2026-08-20-agentic-hard/REPORT.md)) |
-| Throughput | ~35–48 tok/s per stream, ~122–187 tok/s aggregate at concurrency 4 |
+| `core16` + `hard12` | **82.1 %** pass@1 thinking-on · 80.4 % thinking-off ([report](results/2026-08-20-ornith-vs-qwen3.6/REPORT.md)) |
+| `agentic` | **100 %** solved · 95–97 % valid tool calls ([report](results/2026-08-20-agentic-baseline/REPORT.md)) |
+| `agentic-hard` | **agent score 54.6** thinking-on · 50.1 thinking-off ([report](results/2026-08-20-agentic-hard/REPORT.md)) |
+| Throughput | ~35–48 tok/s per stream · ~122–187 tok/s aggregate at concurrency 4 |
 
-**Serve it with thinking off.** The one-shot suites show reasoning costs ~13× the output
-tokens for +1.7 points, and blows the token budget outright at low caps. The agentic suite
-is the exception — there thinking cuts turns by a quarter at no accuracy cost — so if your
-workload is mostly tool loops, turn it back on:
+**Run it with thinking off.** On one-shot suites reasoning costs ~13x the output tokens
+for +1.7 points, and blows the budget outright at low caps.
+
+**Except for tool loops.** There thinking cuts turns by a quarter at no accuracy cost. If
+your workload is mostly agentic, add:
 
 ```
 --default-chat-template-kwargs '{"enable_thinking":true,"preserve_thinking":true}'
 ```
 
 Runner-up: `ornith-1.5-35b-a3b-nvfp4` — same accuracy at its best setting, 38 % fewer
-output tokens, but it collapses without its reasoning block and stalls more often.
+output tokens, but collapses without its reasoning block and stalls more often.
 
-## Why the tests are trustworthy
+## How it works
 
-Every task ships a **reference solution**. `./bench validate` runs all 28 of them against
-the same hidden tests the model will face. If it does not print `28/28`, the test is
-broken and no model score means anything. Run it first, every time.
+```mermaid
+graph LR
+    A[Your endpoint<br/>any OpenAI-compatible URL] --> B[bench run / sweep]
+    B --> C[Hidden executable tests<br/>+ workspace predicates]
+    C --> D[Ranked report<br/>with noise floor]
+    D --> E[bench apply --restart]
+    E --> A
+```
 
-Scoring is pass@1 over executable tests, not string matching and not an LLM judge: the
-model's largest fenced code block is extracted, the hidden tests are appended, and the
-program runs in a subprocess. It passes or it does not.
+A setup is three things at once, and they interact — the same weights score 60.7 % or
+80.4 % depending on one chat-template kwarg:
+
+```mermaid
+graph TD
+    S[One setup] --> C[Serving config<br/>weights, quantisation, vLLM flags]
+    S --> H[Harness<br/>built-in loop · pi · opencode · claude-code]
+    S --> T[Thinking mode<br/>on / off]
+```
+
+| Principle | What it means here |
+|---|---|
+| Measured where it runs | Any OpenAI-compatible endpoint, your hardware, your flags |
+| Both thinking modes, always | Separate rows — they are separate products |
+| Cost next to accuracy | Output tokens, wall-clock, turns, truncation all reported |
+| Two workload shapes | One-shot code generation and multi-turn tool calling disagree |
+| Your harness, your models | `bench harness models` lists what your pi/opencode can already reach |
+| The winner is installable | `bench apply <config> --restart` and you are serving it |
+| Nothing scored on vibes | Hidden unit tests, each proven passable by a reference solution |
+
+## Quick start
+
+Install:
+
+```bash
+pip install -e .
+```
+
+Point it at your endpoint:
+
+```bash
+export BENCH_BASE_URL=http://localhost:8001/v1 BENCH_MODEL=my-model
+```
+
+Prove the tests are passable before trusting any score:
+
+```bash
+./bench validate
+```
+
+Run a suite:
+
+```bash
+./bench run --suite all --thinking --max-tokens 16000 --label "my-model think-ON"
+```
+
+Build the report:
+
+```bash
+./bench report results/*/run-*.json --title "My model" --verdict "..."
+```
+
+`validate` must print `28/28` (and `--suite agentic-all` must print `16/16`). If it does
+not, the test is broken and no model score means anything.
+
+## What the campaigns found
+
+| Campaign | Question | Answer |
+|---|---|---|
+| [2026-08-17](results/2026-08-17-thinking-mode/) | Does thinking mode help a coding agent? | **No.** Thinking off: same or better pass@1, ~13x fewer output tokens, ~32x lower wall-clock |
+| [2026-08-18](results/2026-08-18-vllm-vs-ollama/) | vLLM vs ollama vs llama.cpp | vLLM wins from 3 concurrent clients up; prefix caching is off by default |
+| [2026-08-20](results/2026-08-20-ornith-vs-qwen3.6/) | Should Ornith-1.5-35B-A3B replace Qwen3.6-35B-A3B? | **No.** Ties at its best config, −20 points at the config we deploy |
+| [2026-08-20](results/2026-08-20-agentic-baseline/) | Can the winner drive a tool loop? | **Yes**, 16/16 in both modes. Thinking cuts turns 6.8 &rarr; 5.2 at no accuracy cost |
+| [2026-08-20](results/2026-08-20-agentic-hard/) | Can a harder suite separate configs that both look perfect? | **Yes**, 54.6 vs 50.1 — efficiency against oracle par is what separates them |
+| [2026-08-20](results/2026-08-20-pi-harness/REPORT.md) | Does the harness around the model change the answer? | **Yes, by as much as a model swap.** Same model, same tasks: 67.4 built-in loop, 76.7 `claude-code`, 77.4 `pi`, 79.3 `opencode` |
+| [2026-08-20](results/2026-08-20-pi-harness/REPORT-hard.md) | On tasks that can still be failed, does the harness change the ranking? | **Yes.** `claude-code` 68.2, `opencode` 60.3, `pi` 55.0, built-in 44.9 — prefill spans ~16k to ~179k input tokens per task |
+
+The recurring lesson: benchmark both thinking modes on the workload you actually run.
+Reasoning-trained models collapse without their thinking block; non-reasoning models burn
+thousands of tokens with it. The right answer flips between one-shot generation and tool
+loops.
+
+## The suites
+
+| Suite | Tasks | What it covers |
+|---|---|---|
+| `core16` | 16 | Algorithms, data structures, parsing, Python idiom. **Saturated** — current models score 100 % |
+| `hard12` | 12 | Regex-matching DP, relaxed-JSON parser, Vixie-cron `next_run`, bigint long division, nestable transactions, tiny SQL evaluator, weighted interval scheduling, first-order unification. Models land at 45–75 % |
+| `all` | 28 | `core16` + `hard12` |
+| `agentic` | 8 | Multi-turn tool calling over a sandboxed workspace — 7 tools, scored by a predicate over the final state |
+| `agentic-hard` | 8 | **Ranking tasks.** Hidden tests, decoys, cascading bugs, perf budgets, cases where the correct move is to change nothing. Scored on agent score = solve rate x efficiency vs oracle par |
+| `agentic-all` | 16 | `agentic` + `agentic-hard` |
 
 ## Commands
 
@@ -103,25 +145,20 @@ program runs in a subprocess. It passes or it does not.
 | `./bench validate` | Prove every task's hidden tests are passable |
 | `./bench run` | Run a suite against an endpoint, write a result JSON |
 | `./bench report *.json` | Build a Markdown report with mermaid charts |
-| `./bench harness list` | Which coding harnesses are installed here (`pi`, `opencode`, `claude-code`) |
-| `./bench harness models` | Which models each of them can reach, from **your** config |
-| `./bench harness run --harness opencode -m <provider>/<model>` | Run a suite through a real harness, on a model you pick, instead of our tool loop |
-| `./bench configs` | List known-good serving configs |
+| `./bench harness list` | Which coding harnesses are installed here |
+| `./bench harness models` | Which models each can reach, from **your** config |
+| `./bench harness run --harness opencode -m <p>/<m>` | Run a suite through a real coding agent |
+| `./bench configs` | List serving recipes, and which are sweepable |
 | `./bench apply <name> [--restart]` | Install one as your live server config |
-| `./bench compare <model>...` | DGX box only: swap, run, restore, report — one command |
-| `./bench sweep --setup ...` | DGX box only: sweep serving config x harness x thinking mode and rank the *setups* |
+| `./bench compare <model>...` | DGX box only: swap, run, restore, report |
+| `./bench sweep --setup ...` | DGX box only: rank whole setups, not just models |
 
-Full walkthrough: **[docs/REPRODUCING.md](docs/REPRODUCING.md)**.
-Running this as an AI agent: **[AGENTS.md](AGENTS.md)** — a runbook with checks and guardrails.
-Benchmarking through your own coding agent: **[docs/HARNESSES.md](docs/HARNESSES.md)**.
-Where this is going: **[ROADMAP.md](ROADMAP.md)** — next up is benchmarking through the
-coding harness you actually use (pi, opencode, Claude Code, Codex), not just our tool loop.
+[Full walkthrough](docs/REPRODUCING.md) · [Agent runbook](AGENTS.md) · [Harnesses](docs/HARNESSES.md) · [Roadmap](ROADMAP.md)
 
 ## Sweeping setups, not just models
 
-A setup on your machine is three things at once: the serving config, the harness wrapped
-around the model, and whether thinking is on. `bench compare` sweeps only the model.
-`bench sweep` takes an explicit matrix of setups and ranks them:
+`bench compare` sweeps the model. `bench sweep` takes an explicit matrix of setups and
+ranks them:
 
 ```bash
 ./bench sweep --suite agentic-hard --title "27B dense vs 35B MoE" \
@@ -131,50 +168,89 @@ around the model, and whether thinking is on. `bench compare` sweeps only the mo
   --dry-run
 ```
 
-Four things worth knowing before you drop the `--dry-run`:
+| Behaviour | Detail |
+|---|---|
+| Explicit matrix | Each `--setup` is one real combination; only `thinking=both` expands |
+| One restart per config | Setups are grouped, so six setups over two configs restart twice |
+| Every restart is gated | Refuses without `--yes-restart-endpoint`, and refuses outright when it cannot ask |
+| Launcher restored | On success and on failure; a failing restore is reported, never buried |
+| Ranked within a block | One harness, one thinking mode — a cross-harness winner would be reporting the harness |
 
-- **The matrix is explicit, never a cross-product.** Independent `--configs`/`--harnesses`
-  flags would multiply into combinations that cannot exist. Each `--setup` is one real
-  combination; `thinking=both` is the only expansion, because thinking and non-thinking are
-  two products, not one row.
-- **One restart per serving config, not per setup.** Setups are grouped by config, so a
-  six-setup sweep over two configs restarts the endpoint twice.
-- **Every restart is gated.** Without `--yes-restart-endpoint` a sweep that would restart a
-  shared endpoint asks first, and refuses outright when it cannot ask. Dropping `config=`
-  from every setup sweeps the harness and thinking axes against whatever is already serving,
-  and never touches the launcher. There is deliberately no "swap but do not restart" mode:
-  it would measure the previous config and file the result under the new one's name.
-- **The launcher you started with is put back** — on success and on failure, and a failing
-  restore is reported rather than allowed to bury the error that caused it.
+Drop `config=` from every setup to sweep the harness and thinking axes against whatever is
+already serving, without touching the launcher.
 
-The report ranks setups *within* one harness and one thinking mode and nowhere else: the
-same weights score 67.4 through the built-in loop and 79.3 through opencode here, so a
-single cross-harness "winner" would be reporting the harness. Each block names its own
-winner and says whether the margin clears the noise floor for the sample count used (~8
-points at `--samples 2`, scaled by 1/sqrt(n) above that).
+<details>
+<summary>Why the ranking never crosses harnesses, and how noise is handled</summary>
 
-The ranking is rebuildable from the result files alone — `./bench report <dir>/*.json
---setups` regenerates it without re-running anything, so a sweep that finished but tripped
-over its report is not lost.
+The same weights score 67.4 through the built-in loop and 79.3 through opencode here, so a
+single cross-harness "winner" would be reporting the harness rather than the setup. Each
+block names its own winner and says whether the margin clears the noise floor for the
+sample count used — about 8 points at `--samples 2`, scaled by 1/sqrt(n) above that.
 
-Not every recipe in `configs/` can be swept — `bench configs` marks the ones that cannot and
-says why (a llama.cpp script, a standalone tunable server, a secondary backend on its own
-unit are all fine recipes, just not drivable by the `vllm-qwen` systemd machinery).
+The ranking is rebuildable from the result files alone:
 
-## The suites
+```bash
+./bench report <dir>/*.json --setups
+```
 
-| Suite | Tasks | What it covers |
-|---|---|---|
-| `core16` | 16 | Algorithms, data structures, parsing, Python idiom. **Saturated** — current models score 100 % |
-| `hard12` | 12 | Written when `core16` stopped discriminating: regex-matching DP, a relaxed-JSON parser, Vixie-cron `next_run`, bigint long division, nestable transactions, a tiny SQL evaluator, weighted interval scheduling, first-order unification. Current models land at 45–75 % |
-| `all` | 28 | Both of the above |
-| `agentic-hard` | 8 | **Ranking tasks.** Hidden tests the model never sees, decoys that fail the task if touched, cascading bugs, a performance budget, generalisation to an unseen input, and cases where the correct move is to change nothing. Scored on an **agent score** = solve rate x efficiency against oracle par |
-| `agentic` | 8 | **Multi-turn tool calling.** The model drives a sandboxed workspace through 7 tools — list, read, write, edit, search, run, finish — to reach a goal state: fix a failing test, rename a symbol across files, find a bug by searching, recover from a bad path, implement from a spec, decline to change working code. Scored by a predicate over the final workspace, never by what the model claims |
+A sweep that finished but tripped over its report is not lost.
+
+There is deliberately no "swap but do not restart" mode: it would measure the previous
+config and file the result under the new one's name.
+
+Not every recipe in `configs/` can be swept. `bench configs` marks the ones that cannot and
+says why — a llama.cpp script, a standalone tunable server, and a secondary backend on its
+own systemd unit are all fine recipes, just not drivable by the `vllm-qwen` machinery.
+
+</details>
+
+<details>
+<summary>Why the tests are trustworthy</summary>
+
+Every task ships a **reference solution**. `./bench validate` runs all 28 of them against
+the same hidden tests the model will face. If it does not print `28/28`, the test is broken
+and no model score means anything. Run it first, every time.
+
+Scoring is pass@1 over executable tests, not string matching and not an LLM judge: the
+model's largest fenced code block is extracted, the hidden tests are appended, and the
+program runs in a subprocess. It passes or it does not.
+
+The agentic suites are scored by a predicate over the final workspace state, never by what
+the model claims it did.
 
 When `hard12` saturates too, write the next one — see
 [adding tasks](docs/REPRODUCING.md#adding-tasks-and-suites).
 
-## Serving configs you can adopt
+</details>
+
+<details>
+<summary>Why machine-local benchmarking, in full</summary>
+
+Public benchmarks rank *models* on hardware you don't have, at settings you won't use.
+This one answers a narrower and more useful question: of the things you could actually
+serve on this box, which exact configuration should you run every day?
+
+The answer is machine-local, and that is the point. The best setup for user A is routinely
+the wrong one for user B — different GPU, different memory ceiling, different quantisation
+available, different concurrency, different work. A published score cannot know any of
+that. Running the suite on your own endpoint can.
+
+A configuration is more than a model name — it's the model, the quantisation, the serving
+flags, and the thinking mode, together. Those interact: the same weights score 60.7 % or
+80.4 % on the same suite depending on one chat-template kwarg, and the right answer flips
+between one-shot coding and tool loops.
+
+The same model scores 12 points apart through four different tool loops, so the suites also
+run through the coding agent you actually use (`pi`, `opencode`, `claude-code`). A model
+your editor does not know about is reachable with `--endpoint <url>` on any of the three
+harnesses. Nothing is written to your editor's configuration either way.
+
+Built and used on an **NVIDIA DGX Spark (GB10)**, but the harness itself only needs a URL.
+
+</details>
+
+<details>
+<summary>Serving configs you can adopt</summary>
 
 [`configs/`](configs/) holds complete, benchmarked `vllm serve` recipes. Install one and
 you have a server:
@@ -184,28 +260,13 @@ you have a server:
 ```
 
 Each recipe is listed with its measured pass@1 and throughput, and the reasons its flags
-are the way they are (MoE backends, MTP weight requirements, how the memory fraction is
-computed). Architecture, ports and rollback: [SERVING.md](SERVING.md).
+are the way they are — MoE backends, MTP weight requirements, how the memory fraction is
+computed. Architecture, ports and rollback: [SERVING.md](SERVING.md).
 
-## Findings so far
+</details>
 
-| Campaign | Question | Answer |
-|---|---|---|
-| [2026-08-17](results/2026-08-17-thinking-mode/) | Does thinking mode help a coding agent? | **No.** Thinking off: same or better pass@1, ~13× fewer output tokens, ~32× lower wall-clock |
-| [2026-08-18](results/2026-08-18-vllm-vs-ollama/) | vLLM vs ollama vs llama.cpp | vLLM wins from 3 concurrent clients up; prefix caching is off by default |
-| [2026-08-20](results/2026-08-20-ornith-vs-qwen3.6/) | Should Ornith-1.5-35B-A3B replace Qwen3.6-35B-A3B? | **No.** Ties at its best config, −20 points at the config we deploy |
-| [2026-08-20](results/2026-08-20-agentic-baseline/) | Can the winner drive a tool loop, and does thinking help there? | **Yes**, 16/16 in both modes — the suite is a floor, not a ranking. Thinking cuts turns 6.8 → 5.2 at no accuracy cost |
-| [2026-08-20](results/2026-08-20-agentic-hard/) | Can a harder agentic suite separate configs that both look perfect? | **Yes**, 54.6 vs 50.1. Solve rate still nearly ties; efficiency against oracle par is what separates them |
-| [2026-08-20](results/2026-08-20-pi-harness/REPORT.md) | Does the harness around the model change the answer? | **Yes, by as much as a model swap.** Same model, same tasks: 67.4 through our loop, 76.7 through `claude-code`, 77.4 through `pi`, 79.3 through `opencode`. All solve 100 %, so the top three are tied — the real spread is prefill |
-| [2026-08-20](results/2026-08-20-pi-harness/REPORT-hard.md) | On tasks that can still be failed, does the harness change the ranking? | **Yes.** `claude-code` 68.2, `opencode` 60.3, `pi` 55.0, our loop 44.9 — top two tied inside noise, but the prefill spread is not: ~16k vs ~119k vs ~179k input tokens per task |
-
-The recurring lesson: **always benchmark both thinking modes, on the workload you actually
-run.** Reasoning-trained models collapse without their thinking block; non-reasoning models
-burn thousands of tokens with it — and the right answer flips between one-shot generation
-(thinking off) and multi-turn tool loops (thinking on). Testing one mode, or one workload
-shape, will tell you the wrong thing.
-
-## Layout
+<details>
+<summary>Repository layout</summary>
 
 ```
 bench                  CLI entry point
@@ -217,6 +278,7 @@ benchkit/              the harness
   runner.py            generation, sandboxed test execution, scoring
   report.py            Markdown + mermaid report generator
   serving.py           optional: swap and restart the local vLLM service
+  sweep.py             the setup matrix: grouping, approval gate, launcher restore
 configs/               benchmarked, ready-to-run serving recipes
 results/               one dated directory per campaign: raw JSON, logs, REPORT.md
 AGENTS.md              runbook for an AI agent driving the whole thing
@@ -230,6 +292,16 @@ router.py              OpenAI-compatible router fronting multiple vLLM backends
 Results directories are append-only: a superseded campaign stays next to the one that
 replaced it. Model weights and torch-compile caches are gitignored.
 
-## Licence
+</details>
 
-MIT — see [LICENSE](LICENSE).
+## Get started
+
+```bash
+pip install -e .
+```
+
+```bash
+./bench validate
+```
+
+[**Reproduce a campaign &rarr;**](docs/REPRODUCING.md) · [**Benchmark through your own agent &rarr;**](docs/HARNESSES.md) · [MIT licensed](LICENSE)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This runs the suites against your endpoint and ends in a config file you serve.
 suite it has been run on.
 
 ```bash
-./bench apply qwen3.6-35b-a3b-nvfp4 --restart
+./bench apply qwen3.6-35b-a3b-nvfp4 --restart   # serving host only; restarts vllm-qwen
 ```
 
 | | |
@@ -149,7 +149,7 @@ loops.
 | `./bench harness models` | Which models each can reach, from **your** config |
 | `./bench harness run --harness opencode -m <p>/<m>` | Run a suite through a real coding agent |
 | `./bench configs` | List serving recipes, and which are sweepable |
-| `./bench apply <name> [--restart]` | Install one as your live server config |
+| `./bench apply <name> [--restart]` | Install one as your live server config (serving host) |
 | `./bench compare <model>...` | DGX box only: swap, run, restore, report |
 | `./bench sweep --setup ...` | DGX box only: rank whole setups, not just models |
 
@@ -256,7 +256,7 @@ Built and used on an **NVIDIA DGX Spark (GB10)**, but the harness itself only ne
 you have a server:
 
 ```bash
-./bench apply qwen3.6-35b-a3b-nvfp4 --restart
+./bench apply qwen3.6-35b-a3b-nvfp4 --restart   # serving host only; restarts vllm-qwen
 ```
 
 Each recipe is listed with its measured pass@1 and throughput, and the reasons its flags

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Run a suite:
 Build the report:
 
 ```bash
-./bench report results/*/run-*.json --title "My model" --verdict "..."
+./bench report results/*/my-model-think-*.json --title "My model" --verdict "..."
 ```
 
 `validate` must print `28/28` (and `--suite agentic-all` must print `16/16`). If it does

--- a/SERVING.md
+++ b/SERVING.md
@@ -107,7 +107,7 @@ runs with `VLLM_USE_V2_MODEL_RUNNER=0`.
   `--attention-backend flashinfer`: Qwen3.6-35B-A3B is MoE and needs the GB10
   linear kernels. These flags do **not** transfer to a dense model — the
   Qwen3.8-27B recipe (stock image, DSpark drafter at k=7, no MoE flags) is kept
-  intact in `start-qwen.sh.qwen38.bak` and `serve-qwen38-4bit.sh`.
+  intact in `configs/qwen3.8-27b-nvfp4-dspark.sh` and `serve-qwen38-4bit.sh`.
 - MTP speculative decoding, 2 tokens, triton MoE backend for the draft pass.
 - Do not benchmark the first engine instance after a cold `vllm-cache` — the
   first start JIT-compiles kernels *during* inference and reads far slower than

--- a/SERVING.md
+++ b/SERVING.md
@@ -62,7 +62,9 @@ curl -s localhost:8001/v1/chat/completions \
   -d '{"model":"montimage-dgx-spark","messages":[{"role":"user","content":"hi"}]}'
 
 # thinking off for this request (default is ON)
-  -d '{"model":"montimage-dgx-spark","messages":[...],
+curl -s localhost:8001/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"montimage-dgx-spark","messages":[{"role":"user","content":"hi"}],
        "chat_template_kwargs":{"enable_thinking":false}}'
 ```
 

--- a/configs/ornith-1.5-35b-a3b-nvfp4.sh
+++ b/configs/ornith-1.5-35b-a3b-nvfp4.sh
@@ -3,10 +3,10 @@
 # Runs attached (no -d) so systemd owns the lifecycle.
 #
 # Restored as the default on 2026-08-17, reverting the 2026-08-17 swap to
-# Qwen3.8-27B-NVFP4. That version is kept as start-qwen.sh.qwen38.bak (dense
-# model, stock aarch64 image, DSpark drafter at k=7) -- copy it back over this
-# file and `systemctl --user restart vllm-qwen` to switch again. Clients are
-# unaffected either way: same port 8801, same alias, same router on :8001.
+# Qwen3.8-27B-NVFP4. That recipe is kept as configs/qwen3.8-27b-nvfp4-dspark.sh
+# (dense model, stock aarch64 image, DSpark drafter at k=7) -- switch back with
+# `./bench apply qwen3.8-27b-nvfp4-dspark --restart`. Clients are unaffected
+# either way: same port 8801, same alias, same router on :8001.
 #
 # This is a MoE model, so it needs the mia-vllm-gb10 build and the
 # --moe-backend / --linear-backend flashinfer_b12x flags below; the Qwen3.8

--- a/configs/qwen3.6-35b-a3b-nvfp4.sh
+++ b/configs/qwen3.6-35b-a3b-nvfp4.sh
@@ -3,10 +3,10 @@
 # Runs attached (no -d) so systemd owns the lifecycle.
 #
 # Restored as the default on 2026-08-17, reverting the 2026-08-17 swap to
-# Qwen3.8-27B-NVFP4. That version is kept as start-qwen.sh.qwen38.bak (dense
-# model, stock aarch64 image, DSpark drafter at k=7) -- copy it back over this
-# file and `systemctl --user restart vllm-qwen` to switch again. Clients are
-# unaffected either way: same port 8801, same alias, same router on :8001.
+# Qwen3.8-27B-NVFP4. That recipe is kept as configs/qwen3.8-27b-nvfp4-dspark.sh
+# (dense model, stock aarch64 image, DSpark drafter at k=7) -- switch back with
+# `./bench apply qwen3.8-27b-nvfp4-dspark --restart`. Clients are unaffected
+# either way: same port 8801, same alias, same router on :8001.
 #
 # This is a MoE model, so it needs the mia-vllm-gb10 build and the
 # --moe-backend / --linear-backend flashinfer_b12x flags below; the Qwen3.8

--- a/configs/qwen3.8-27b-nvfp4-dspark.sh
+++ b/configs/qwen3.8-27b-nvfp4-dspark.sh
@@ -4,7 +4,7 @@
 #
 # Re-swapped from Qwen3.6-35B-A3B-NVFP4 on 2026-08-20 for a trial run before a
 # final decision. Roll back with:
-#   cp start-qwen.sh.qwen36.bak start-qwen.sh && systemctl --user restart vllm-qwen
+#   ./bench apply qwen3.6-35b-a3b-nvfp4 --restart
 #
 # NOTE (2026-08-20): enable_thinking defaults to FALSE here, unlike the 08-17
 # version. Thinking ON with this vLLM chat template scored 62.5% pass@1 on the
@@ -12,9 +12,10 @@
 # scored 96.9% and 32x faster. Clients opt in per request with
 # chat_template_kwargs:{"enable_thinking":true}.
 #
-# Swapped from Qwen3.6-35B-A3B-NVFP4 on 2026-08-17. Previous version kept as
-# start-qwen.sh.qwen36.bak -- restore it and `systemctl --user restart vllm-qwen`
-# to roll back. Clients are unaffected either way: same port, same alias.
+# Swapped from Qwen3.6-35B-A3B-NVFP4 on 2026-08-17. That recipe is kept as
+# configs/qwen3.6-35b-a3b-nvfp4.sh -- roll back with
+# `./bench apply qwen3.6-35b-a3b-nvfp4 --restart`. Clients are unaffected either
+# way: same port, same alias.
 #
 # Recipe from github.com/0xBakeer/Qwen3.8-27B-4-bit-on-a-single-DGX-Spark,
 # reproduced on this machine (edit-heavy 58-61 tok/s single stream, ~234 tok/s

--- a/docs/HARNESSES.md
+++ b/docs/HARNESSES.md
@@ -51,7 +51,9 @@ accept it, and none of them writes to your own configuration to do it:
 | `pi` | a throwaway catalogue in the run's temp dir holding one synthetic provider and nothing else, handed over as `PI_CODING_AGENT_DIR` |
 
 In this mode the harness catalogue does not apply, so `--model` must name the id that
-endpoint serves — it is checked against the endpoint's `/models` before the run starts:
+endpoint serves — it is checked against the endpoint's `/models` before the run starts.
+`montimage-dgx-spark` below is the id *this* DGX serves; use whatever your own
+`/v1/models` reports:
 
 ```bash
 ./bench harness run --harness opencode --endpoint http://localhost:8001/v1 \
@@ -113,6 +115,10 @@ adapter to configure. `list_models()` shells out to `pi --list-models` and retur
 provider/model pairs it prints; `available()` then re-checks the choice against
 `~/.pi/agent/models.json` before a run rather than after a confusing result.
 
+`local-dgx/montimage-dgx-spark` is the entry *this* box's pi catalogue holds for the
+local vLLM. On your machine, substitute a `provider/model` pair that
+`./bench harness models` actually reports.
+
 ```bash
 ./bench harness models --harness pi
 ./bench harness run --harness pi -m local-dgx/montimage-dgx-spark
@@ -145,7 +151,9 @@ best-effort. A model that needs a particular `compat.thinkingFormat` (the local 
 
 ### Thinking
 
-`--thinking off` / `--thinking high`, selected by the `--thinking` flag as everywhere else.
+The adapter passes pi `--thinking off` or `--thinking high`, chosen by benchkit's own
+`--thinking` flag — which is a boolean switch, so you write `--thinking`, not
+`--thinking high`.
 pi maps those onto whatever the provider's `compat.thinkingFormat` says; for the local
 provider that is `qwen-chat-template`, i.e. the same `enable_thinking` kwarg the direct
 suites toggle.

--- a/docs/REPRODUCING.md
+++ b/docs/REPRODUCING.md
@@ -15,7 +15,7 @@ service.
 ```bash
 git clone https://github.com/luongnv89/dgx-spark-llm-lab.git
 cd dgx-spark-llm-lab
-pip install -r requirements.txt        # just `openai`
+pip install -e .                       # openai + aiohttp
 ```
 
 ## 2. Point it at a server
@@ -47,6 +47,20 @@ broken — fix it before reading any model score.
 Results land in `results/<today>/<label>.json` and the pass/fail of every generation
 streams to the terminal as it happens.
 
+`results/` is append-only: one dated directory per campaign, and a superseded campaign
+stays on disk next to the one that replaced it. Never delete or overwrite a campaign
+directory.
+
+The two oldest campaigns — `results/2026-08-17-thinking-mode/` and
+`results/2026-08-18-vllm-vs-ollama/` — each carry their own copy of the harness that
+produced them (`bench.py`, `tasks.py`, `validate.py`, plus a few campaign-specific
+probes). **Those duplicates are a deliberate freeze, not drift.** They predate the
+`benchkit/` package, so there is no current root-level `bench.py` for them to have
+drifted from — shipping the harness alongside its own results is the only thing that
+keeps those two campaigns reproducible. Campaigns from `2026-08-20` onward contain
+only `REPORT.md`, the run JSON and logs, because `benchkit/` in the repo is the
+harness that produced them.
+
 Useful flags:
 
 | Flag | Default | Notes |
@@ -68,12 +82,16 @@ campaigns in `results/`.
 ## 5. Build the report
 
 ```bash
-./bench report results/2026-08-20-*/run-*.json \
+./bench report results/<today>/my-model-think-*.json \
   --title "My model vs the incumbent" \
   --question "Should we swap?" \
   --verdict "No — ties on accuracy, doubles the latency." \
-  --notes my-analysis.md
+  --out results/<today>/REPORT.md
 ```
+
+`--notes <file.md>` splices your own written analysis into the report. `bench report`
+refuses to overwrite an existing `REPORT.md`, so pass `--out` or `--force` when you
+re-run it against a directory that already has one.
 
 Writes `REPORT.md` next to the results: a setup table, a per-run results table, four
 mermaid charts (pass@1, wall-clock, output tokens, accuracy by difficulty), a per-task

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
-# The harness talks plain OpenAI-compatible HTTP; this is the only dependency.
-openai>=1.40
+# Kept in step with pyproject.toml -- `pip install -e .` is equivalent.
+# The harness talks plain OpenAI-compatible HTTP; router.py needs aiohttp.
+openai>=2.0,<3
+aiohttp>=3.8,<4

--- a/start-qwen.sh
+++ b/start-qwen.sh
@@ -3,10 +3,10 @@
 # Runs attached (no -d) so systemd owns the lifecycle.
 #
 # Restored as the default on 2026-08-17, reverting the 2026-08-17 swap to
-# Qwen3.8-27B-NVFP4. That version is kept as start-qwen.sh.qwen38.bak (dense
-# model, stock aarch64 image, DSpark drafter at k=7) -- copy it back over this
-# file and `systemctl --user restart vllm-qwen` to switch again. Clients are
-# unaffected either way: same port 8801, same alias, same router on :8001.
+# Qwen3.8-27B-NVFP4. That recipe is kept as configs/qwen3.8-27b-nvfp4-dspark.sh
+# (dense model, stock aarch64 image, DSpark drafter at k=7) -- switch back with
+# `./bench apply qwen3.8-27b-nvfp4-dspark --restart`. Clients are unaffected
+# either way: same port 8801, same alias, same router on :8001.
 #
 # This is a MoE model, so it needs the mia-vllm-gb10 build and the
 # --moe-backend / --linear-backend flashinfer_b12x flags below; the Qwen3.8


### PR DESCRIPTION
Closes #43
Closes #42

## What changed

The configuration a reader should actually serve sat ~70 lines down, under four
paragraphs of rationale. It is now the first content section, behind a copy-paste
`bench apply` line.

| Position | Before | After |
|---|---|---|
| Winning recipe + `bench apply` | line ~70 | first section |
| Rationale prose (why machine-local) | first 5 paragraphs | collapsed `<details>` |
| Findings table | line ~190 | third section |
| Architecture visual | none | 2 mermaid diagrams |

## Factual fix

The quick start claimed `./bench validate` prints `44/44`. It prints `28/28` —
44 is `all` (28) plus `agentic-all` (16). Verified against `./bench suites` and
`AGENTS.md`. The same README already said `28/28` correctly further down, so the
two statements contradicted each other.

## Also

- Added the missing `agentic-all` suite (16 tasks) to the suites table — it exists
  in the CLI but was not listed.
- Two mermaid diagrams: the benchmark → decide → install loop, and the three axes
  that make up a setup. The three-axis claim is the repo's central argument and was
  prose only.
- Added `sweep.py` to the layout block (shipped in #57).
- Static badges only — licence, Python floor, validate count, reference hardware.
  No star or download counts, since there is no real data for those.
- Sweep caveats, test-trustworthiness notes, the machine-local rationale,
  serving-config notes and the repo layout moved into `<details>` blocks.

## Preservation

No original content was dropped; everything not in the visible flow is in a
`<details>` block. Structured content (tables, code, diagrams) is now 62% of
non-blank lines, up from roughly a third.

Two paragraphs inside `<details>` blocks exceed the style guide's 3-sentence limit.
Both are verbatim original prose — preservation was allowed to win over the limit
there. Every paragraph in the visible portion complies.

## Verification

- All 17 relative links resolve to files that exist.
- All 3 in-page anchors match their headings.
- No emoji, no banned filler phrases.
- Numbers are unchanged from the previous README except the `44/44` correction;
  suite names and counts checked against `./bench suites`, config names against
  `./bench configs`.

## Worth deciding separately

The "Best recipe right now" block hardcodes the 2026-08-20 round and will go stale
the next time a sweep names a different winner. Having `bench sweep` emit that table
so it regenerates would be a reasonable follow-up.



---

## Widened to close #43

The original commit restructured `README.md`. Review linked this PR to #43, whose
acceptance criteria cover all the docs, so three further commits verified every
documented command against the CLI and recorded the `results/` archive convention.

Commands were classified as *runs on a clean checkout* or *requires the serving
host*, and the second group is now marked as such. What was actually broken:

| File | Problem | Fix |
|---|---|---|
| `AGENTS.md`, `docs/REPRODUCING.md` | `pip install -r requirements.txt` installs the wrong set — `requirements.txt` pins `openai>=1.40` and omits `aiohttp`, which `router.py:19` imports | `pip install -e .` |
| `docs/REPRODUCING.md` | Report example wrote into a committed campaign dir whose `REPORT.md` exists (`bench report` refuses to overwrite) and passed `--notes my-analysis.md`, a file that does not exist | `--out`, and the `--force` rule documented |
| `AGENTS.md` | Step 5 had the same overwrite/`--notes` pitfall | same |
| `README.md`, `AGENTS.md`, `docs/REPRODUCING.md` | `run-*.json` report globs never matched a run made by following the preceding step, whose label slugs to `<label>.json` | globs match the labels actually used |
| `SERVING.md` | Thinking-off example was a bare `-d` fragment — no `curl`, no URL, literal `[...]` | runnable request |
| `AGENTS.md`, `README.md`, `CLAUDE.md` | `bench apply --restart` rewrites `start-qwen.sh` and restarts the shared endpoint, with no host warning | marked; AGENTS.md Step 7 states the approval rule |
| `docs/HARNESSES.md` | DGX-specific model aliases unmarked; `--thinking high` implied an argument, but benchkit's `--thinking` is a boolean switch | both corrected |
| `CLAUDE.md` | Install line and runtime floor still claimed `openai>=1.40` | aligned with `pyproject.toml` |

## Acceptance Criteria Verification

| # | Criterion | Status | Evidence |
|---|---|---|---|
| 1 | Every shell command in `README.md`, `AGENTS.md`, `SERVING.md`, `docs/*.md` runs on a clean checkout, or is marked as requiring the DGX host | pass | All 26 shell blocks classified and verified against `benchkit/cli.py`; the eight defects above fixed; every runnable `bench apply` now carries a host marker |
| 2 | `docs/REPRODUCING.md` states each `results/<date>-<name>/` carries its own frozen harness copy, so the duplicates are intentional | pass | New paragraph under *4. Run a suite*. Inventory verified: `bench.py`/`tasks.py`/`validate.py` exist under exactly `2026-08-17-thinking-mode/` and `2026-08-18-vllm-vs-ollama/`; no campaign from `2026-08-20` on has any `.py`; `git log --all -- bench.py tasks.py validate.py` is empty, so no root equivalent ever existed |
| 3 | `./bench validate && ./bench validate --suite agentic-all` passes at 44/44 | pass | Ran both: `28/28 reference solutions pass`, `16/16 oracles solve their task` |

## Decision Record

**Root cause:** the docs were written against the pre-`benchkit` tree and drifted; nothing re-verified them after the package landed.

**Options considered:** (a) mark the PR `Type: chore` and leave #43 open; (b) link #43 as a mention only; (c) widen the PR to satisfy #43.

**Options rejected:** (a) and (b) leave verified-broken commands in the tree behind a tracking ticket.

**Selected option:** (c). Every command classified and the broken ones fixed in the same PR that links the issue.

**Residual risk:** `requirements.txt` still pins `openai>=1.40` and omits `aiohttp`, diverging from `pyproject.toml`. No doc references it any more; dependency changes belong with the upgrade work (#23/#27). `SERVING.md` still references `start-qwen.sh.qwen38.bak`, which does not exist — that dangling reference spans docs *and* scripts and is owned by #42, a declared dependency of #43.



---

## Also closes #42

The docs pass deferred two items as out of scope; both are now fixed.

**Dangling rollback references.** Six places named a `.bak` launcher as the
rollback path. No `.bak` file exists in the tree or anywhere in git history, so
the documented recovery could not be performed. #42 lists four; there are two
more in `configs/qwen3.8-27b-nvfp4-dspark.sh` pointing at an equally absent
`start-qwen.sh.qwen36.bak`. All six now name the config that actually holds the
recipe, with `./bench apply <config> --restart` as the mechanism. Comments only —
no executable line changed in any script.

**`requirements.txt`.** Pinned `openai>=1.40` and omitted `aiohttp`, while
`pyproject.toml` declares `openai>=2.0,<3` and `aiohttp>=3.8,<4` and `router.py`
imports aiohttp. Installing from it produced a tree that could not run the
router. Now matches pyproject, so both install commands agree.

### Acceptance Criteria Verification — #42

| # | Criterion | Status | Evidence |
|---|---|---|---|
| 1 | All four references point at a file that exists | pass | All six (the four listed plus two unlisted) now point at `configs/qwen3.8-27b-nvfp4-dspark.sh` or `configs/qwen3.6-35b-a3b-nvfp4.sh`, both present and both listed by `./bench configs` |
| 2 | Repo-wide check finds no documentation reference to a nonexistent repo-relative file | pass | Swept `*.md` and `*.sh` outside `results/`: no `.bak` references remain. The only surviving mentions are in `MODERNIZATION_PLAN.md` / `MODERNIZATION_REPORT.md`, which record F-DOCS-001 as an audit finding and state the file does not exist — left intact so the audit record stays accurate |
| 3 | `./bench validate && ./bench validate --suite agentic-all` passes at 44/44 | pass | Ran both after the change: 28/28 and 16/16 |
