### PR TITLE
fix: pin vLLM image by SHA-256 digest in all launchers (#25)

### DIFF
--- a/Dockerfile.gemma
+++ b/Dockerfile.gemma
@@ -5,7 +5,7 @@
 #
 # Scoped to the gemma backend on purpose: the Qwen NVFP4 container keeps
 # running the untouched upstream image.
-FROM ghcr.io/miaai-lab/mia-vllm-gb10-linear-b12x:latest
+FROM ghcr.io/miaai-lab/mia-vllm-gb10-linear-b12x@sha256:19627342e1da2607f4db50745dca30e57d7dd0ebff06062f03fd69b43a252931
 
 # torch/flashinfer are pinned to this image's CUDA 13 arm64 build -- never let
 # a transitive resolve swap them out.

--- a/configs/README.md
+++ b/configs/README.md
@@ -22,14 +22,14 @@ points, not gospel.
 
 ## The recipes
 
-| Config | Model | Quant | VRAM budget | Measured | Use it when |
-|---|---|---|---|---|---|
-| `qwen3.6-35b-a3b-nvfp4` | Qwen3.6-35B-A3B | NVFP4 | 0.62 (~74 GB) | **82.1 % pass@1**, **100 % agentic**, 47.8 tok/s | **Current winner.** Best accuracy/latency mix for coding agents |
-| `ornith-1.5-35b-a3b-nvfp4` | Ornith-1.5-35B-A3B | NVFP4 | 0.62 (~74 GB) | 80.4 % pass@1, 38.9 tok/s | Runner-up. Fewer output tokens per answer, but it collapses without its reasoning block |
-| `qwen3.8-27b-nvfp4-dspark` | Qwen3.8-27B (dense) | NVFP4 | 0.70 | 96.9 % on core16 only | Dense-model comparison; much slower TTFT for agent loops |
-| `qwen3.8-27b-nvfp4-tunable` | Qwen3.8-27B (dense) | NVFP4 | env-tunable | — | Sweeping speculative-decoding settings (`K`, `DRAFTER`, `SPEC`) |
-| `gemma4-12b-w4a16` | Gemma 4 12B | QAT W4A16 | 0.16 | — | Small secondary backend alongside the primary, on port 8802 |
-| `llamacpp-qwen3.8-27b-bench.sh` | Qwen3.8-27B GGUF | Q4_K_M | — | ~11.6 tok/s | llama.cpp comparison, not a vLLM recipe |
+| Config | Model | Quant | VRAM budget | Image digest | Measured | Use it when |
+|---|---|---|---|---|---|---|
+| `qwen3.6-35b-a3b-nvfp4` | Qwen3.6-35B-A3B | NVFP4 | 0.62 (~74 GB) | `@sha256:1962734…` | **82.1 % pass@1**, **100 % agentic**, 47.8 tok/s | **Current winner.** Best accuracy/latency mix for coding agents |
+| `ornith-1.5-35b-a3b-nvfp4` | Ornith-1.5-35B-A3B | NVFP4 | 0.62 (~74 GB) | `@sha256:1962734…` | 80.4 % pass@1, 38.9 tok/s | Runner-up. Fewer output tokens per answer, but it collapses without its reasoning block |
+| `qwen3.8-27b-nvfp4-dspark` | Qwen3.8-27B (dense) | NVFP4 | 0.70 | `v0.27.1-aarch64` | 96.9 % on core16 only | Dense-model comparison; much slower TTFT for agent loops |
+| `qwen3.8-27b-nvfp4-tunable` | Qwen3.8-27B (dense) | NVFP4 | env-tunable | — | — | Sweeping speculative-decoding settings (`K`, `DRAFTER`, `SPEC`) |
+| `gemma4-12b-w4a16` | Gemma 4 12B | QAT W4A16 | 0.16 | built from `@sha256:1962734…` | — | Small secondary backend alongside the primary, on port 8802 |
+| `llamacpp-qwen3.8-27b-bench.sh` | Qwen3.8-27B GGUF | Q4_K_M | — | ~11.6 tok/s | — | llama.cpp comparison, not a vLLM recipe |
 
 "Measured" links to the campaign in [`../results/`](../results/) that produced it.
 Where a cell is blank, that config has not been put through the coding suite.

--- a/configs/ornith-1.5-35b-a3b-nvfp4.sh
+++ b/configs/ornith-1.5-35b-a3b-nvfp4.sh
@@ -14,7 +14,7 @@
 set -euo pipefail
 
 MODEL_ID="ornith-ai/Ornith-1.5-35B-A3B-NVFP4"
-IMAGE="ghcr.io/miaai-lab/mia-vllm-gb10-linear-b12x:latest"
+IMAGE="ghcr.io/miaai-lab/mia-vllm-gb10-linear-b12x@sha256:19627342e1da2607f4db50745dca30e57d7dd0ebff06062f03fd69b43a252931"
 NAME="vllm-qwen"
 PORT="${QWEN_PORT:-8801}"
 # 0.62 of the 119 GB unified pool (~74 GB): weights 24.8 GB + ~45 GB KV.

--- a/configs/qwen3.6-35b-a3b-nvfp4.sh
+++ b/configs/qwen3.6-35b-a3b-nvfp4.sh
@@ -14,7 +14,7 @@
 set -euo pipefail
 
 MODEL_ID="unsloth/Qwen3.6-35B-A3B-NVFP4"
-IMAGE="ghcr.io/miaai-lab/mia-vllm-gb10-linear-b12x:latest"
+IMAGE="ghcr.io/miaai-lab/mia-vllm-gb10-linear-b12x@sha256:19627342e1da2607f4db50745dca30e57d7dd0ebff06062f03fd69b43a252931"
 NAME="vllm-qwen"
 PORT="${QWEN_PORT:-8801}"
 # 0.62 of the 119 GB unified pool (~74 GB): weights 24.8 GB + ~45 GB KV.

--- a/start-qwen.sh
+++ b/start-qwen.sh
@@ -14,7 +14,7 @@
 set -euo pipefail
 
 MODEL_ID="unsloth/Qwen3.6-35B-A3B-NVFP4"
-IMAGE="ghcr.io/miaai-lab/mia-vllm-gb10-linear-b12x:latest"
+IMAGE="ghcr.io/miaai-lab/mia-vllm-gb10-linear-b12x@sha256:19627342e1da2607f4db50745dca30e57d7dd0ebff06062f03fd69b43a252931"
 NAME="vllm-qwen"
 PORT="${QWEN_PORT:-8801}"
 # 0.62 of the 119 GB unified pool (~74 GB): weights 24.8 GB + ~45 GB KV.


### PR DESCRIPTION
## What

Pin the vLLM container image by `@sha25:` digest in all four launchers that reference it:

| File | Before | After |
|------|--------|-------|
| `start-qwen.sh:17` | `mia-vllm-gb10-linear-b12x:latest` | `mia-vllm-gb10-linear-b12x@sha256:19627342e1da2607f4db50745dca30e57d7dd0ebff06062f03fd69b43a252931` |
| `Dockerfile.gemma:8` | `mia-vllm-gb10-linear-b12x:latest` | `mia-vllm-gb10-linear-b12x@sha256:19627342e1da2607f4db50745dca30e57d7dd0ebff06062f03fd69b43a252931` |
| `configs/ornith-1.5-35b-a3b-nvfp4.sh:17` | `mia-vllm-gb10-linear-b12x:latest` | same digest |
| `configs/qwen3.6-35b-a3b-nvfp4.sh:17` | `mia-vllm-gb10-linear-b12x:latest` | same digest |

Also updated `configs/README.md` to record the digest alongside each config's measured numbers.

## Why

An upstream push to `:latest` silently changes the serving stack under a 'known-good config' — the one thing `configs/README.md` promises will not happen.

Closes #25