### PR TITLE
refactor: finish Phase P3 — split oversized functions, harden adapters (#33, #34)

### DIFF
--- a/benchkit/agentic/env.py
+++ b/benchkit/agentic/env.py
@@ -15,6 +15,20 @@ import tempfile
 MAX_OUTPUT = 4000
 
 
+def materialise(files, root):
+    """Write *files* into *root*, validating every path to prevent traversal.
+
+    This is the single point of defence against `F-BUG-001` — every caller
+    validates once, then reuses the same safe directory.
+    """
+    for p, body in files.items():
+        _safe_path(p)
+        full = os.path.join(root, p)
+        os.makedirs(os.path.dirname(full), exist_ok=True)
+        with open(full, "w") as f:
+            f.write(body)
+
+
 def _no_tool_calls(solved: bool, tool_calls: int) -> tuple[bool, str | None]:
     """Refuse to score a run as solved when the model made zero tool calls.
 
@@ -141,14 +155,7 @@ class Workspace:
     def _materialise_and_run(self, cmd, sync_back=False):
         d = tempfile.mkdtemp(prefix="benchkit-agentic-")
         try:
-            for p, body in self.files.items():
-                # Re-validate each key before joining — a bad key cannot
-                # reach the filesystem by another route.
-                _safe_path(p)
-                full = os.path.join(d, p)
-                os.makedirs(os.path.dirname(full), exist_ok=True)
-                with open(full, "w") as f:
-                    f.write(body)
+            materialise(self.files, d)
             isolate = os.environ.get("BENCH_ISOLATE", "").lower() in ("1", "true", "yes")
             try:
                 if isolate:
@@ -213,12 +220,7 @@ class Workspace:
         """
         d = tempfile.mkdtemp(prefix="benchkit-check-")
         try:
-            for p, body in dict(self.files, **(extra_files or {})).items():
-                _safe_path(p)
-                full = os.path.join(d, p)
-                os.makedirs(os.path.dirname(full), exist_ok=True)
-                with open(full, "w") as f:
-                    f.write(body)
+            materialise(dict(self.files, **(extra_files or {})), d)
             try:
                 r = subprocess.run([sys.executable, path], cwd=d, capture_output=True,
                                    text=True, timeout=self.run_timeout)

--- a/benchkit/agentic/loop.py
+++ b/benchkit/agentic/loop.py
@@ -48,6 +48,69 @@ def _args_of(tc):
     return args, False
 
 
+def _chat(client, cfg, messages):
+    """One chat completion with the suite's tools attached."""
+    kw = {}
+    if cfg.temperature is not None:
+        kw["temperature"] = cfg.temperature
+    return client.chat.completions.create(
+        model=cfg.model, messages=messages, tools=TOOLS, tool_choice="auto",
+        max_tokens=cfg.max_tokens,
+        extra_body={"chat_template_kwargs": {"enable_thinking": cfg.thinking,
+                                             "preserve_thinking": cfg.thinking}},
+        **kw)
+
+
+def _assistant_message(msg, calls):
+    return {"role": "assistant",
+            "content": msg.content or "",
+            "tool_calls": [{"id": c.id, "type": "function",
+                            "function": {"name": c.function.name,
+                                         "arguments": c.function.arguments}}
+                           for c in calls] or None}
+
+
+def _execute_calls(ws, messages, calls):
+    """Run one turn's tool calls against the workspace.
+
+    Returns (malformed, unknown) -- the hygiene counts this turn added.
+    """
+    malformed = unknown = 0
+    for tc in calls:
+        name = tc.function.name
+        args, bad = _args_of(tc)
+        if bad:
+            malformed += 1
+            out = ("error: arguments were not a JSON object. Send valid JSON "
+                   "matching the tool's schema.")
+            ws.record(name, {"_raw": str(tc.function.arguments)[:200]}, False, out)
+        else:
+            ok, out = call(ws, name, args)
+            if not ok and out.startswith("no such tool"):
+                unknown += 1
+        messages.append({"role": "tool", "tool_call_id": tc.id, "content": out})
+    return malformed, unknown
+
+
+def _score(ws, task):
+    """Check the final workspace, then apply the no-tool-calls guard.
+
+    Returns (solved, detail, total_calls).
+    """
+    try:
+        solved, detail = task["check"](ws)
+    except Exception as e:  # noqa: BLE001 — a broken predicate is a test bug, report it
+        solved, detail = False, f"check raised {e!r}"
+
+    total_calls = len(ws.calls)
+    # A model that replies in prose with no tool calls has not done any work.
+    solved, new_detail = _no_tool_calls(solved, total_calls)
+    if new_detail:
+        solved = False
+        detail = new_detail
+    return solved, detail, total_calls
+
+
 def run_task(client, cfg, task, sample, max_turns=MAX_TURNS):
     t0 = time.perf_counter()
     ws = Workspace(task["files"])
@@ -60,43 +123,18 @@ def run_task(client, cfg, task, sample, max_turns=MAX_TURNS):
 
     try:
         for turns in range(1, max_turns + 1):
-            kw = {}
-            if cfg.temperature is not None:
-                kw["temperature"] = cfg.temperature
-            resp = client.chat.completions.create(
-                model=cfg.model, messages=messages, tools=TOOLS, tool_choice="auto",
-                max_tokens=cfg.max_tokens,
-                extra_body={"chat_template_kwargs": {"enable_thinking": cfg.thinking,
-                                                     "preserve_thinking": cfg.thinking}},
-                **kw)
+            resp = _chat(client, cfg, messages)
             if resp.usage:
                 completion_tokens += resp.usage.completion_tokens or 0
             msg = resp.choices[0].message
             calls = msg.tool_calls or []
-            messages.append({
-                "role": "assistant",
-                "content": msg.content or "",
-                "tool_calls": [{"id": c.id, "type": "function",
-                                "function": {"name": c.function.name,
-                                             "arguments": c.function.arguments}}
-                               for c in calls] or None,
-            })
+            messages.append(_assistant_message(msg, calls))
             if not calls:
                 stop_reason = "no_tool_call"
                 break
-            for tc in calls:
-                name = tc.function.name
-                args, bad = _args_of(tc)
-                if bad:
-                    malformed += 1
-                    out = ("error: arguments were not a JSON object. Send valid JSON "
-                           "matching the tool's schema.")
-                    ws.record(name, {"_raw": str(tc.function.arguments)[:200]}, False, out)
-                else:
-                    ok, out = call(ws, name, args)
-                    if not ok and out.startswith("no such tool"):
-                        unknown += 1
-                messages.append({"role": "tool", "tool_call_id": tc.id, "content": out})
+            m, u = _execute_calls(ws, messages, calls)
+            malformed += m
+            unknown += u
             if ws.finished is not None:
                 stop_reason = "finished"
                 break
@@ -105,17 +143,7 @@ def run_task(client, cfg, task, sample, max_turns=MAX_TURNS):
         error = f"{type(e).__name__}: {e}"
 
     elapsed = time.perf_counter() - t0
-    try:
-        solved, detail = task["check"](ws)
-    except Exception as e:  # noqa: BLE001 — a broken predicate is a test bug, report it
-        solved, detail = False, f"check raised {e!r}"
-
-    total_calls = len(ws.calls)
-    # A model that replies in prose with no tool calls has not done any work.
-    solved, new_detail = _no_tool_calls(solved, total_calls)
-    if new_detail:
-        solved = False
-        detail = new_detail
+    solved, detail, total_calls = _score(ws, task)
 
     par = par_calls(task)
     # Efficiency only means something for a solved task: failing in three calls is

--- a/benchkit/agentic/loop.py
+++ b/benchkit/agentic/loop.py
@@ -205,6 +205,17 @@ def summarize(results, cfg, wall, n_tasks):
     common["mean_par_calls"] = (
         sum(r["par_calls"] for r in results if r.get("par_calls"))
         / max(1, sum(1 for r in results if r.get("par_calls"))))
+    # Token stats keep the agentic semantics: every row counts, including the
+    # zero-token rows a backend that reports no usage produces. _summarize_common
+    # drops falsy values for the one-shot runner; that would inflate these.
+    common["mean_completion_tokens"] = mean("completion_tokens")
+    common["median_completion_tokens"] = (
+        sorted(r["completion_tokens"] for r in results)[len(results) // 2]
+        if results else None)
+    common["mean_tok_s"] = mean("tok_s")
+    common["mean_ttft"] = None  # the harness loop never measures TTFT
+    common["aggregate_tok_s"] = (sum(r["completion_tokens"] for r in results) / wall) \
+        if wall else None
     common["truncated"] = 0
     common["errored"] = sum(1 for r in results if r["stop_reason"] == "error")
     # --- agentic-specific ---

--- a/benchkit/agentic/loop.py
+++ b/benchkit/agentic/loop.py
@@ -8,8 +8,8 @@ by flailing through twenty calls is not the same as one that solves it in four.
 import concurrent.futures as cf
 import json
 import time
-from dataclasses import asdict
 
+from ..runner import _summarize_common
 from .env import Workspace, _no_tool_calls, call
 from .tools import TOOLS, SYSTEM
 
@@ -155,17 +155,11 @@ def run(tasks, cfg, on_result=None, max_turns=MAX_TURNS):
 
 
 def summarize(results, cfg, wall, n_tasks):
-    by_task = {}
-    for r in results:
-        by_task.setdefault(r["task"], []).append(r)
+    common = _summarize_common(results, cfg, wall, n_tasks)
 
     def mean(key):
         vals = [r[key] for r in results if r.get(key) is not None]
         return sum(vals) / len(vals) if vals else None
-
-    def rate(pred):
-        sel = [r for r in results if pred(r)]
-        return (sum(1 for r in sel if r["passed"]) / len(sel)) if sel else None
 
     total_calls = sum(r["tool_calls"] for r in results)
     total_failed = sum(r["failed_calls"] for r in results)
@@ -175,38 +169,28 @@ def summarize(results, cfg, wall, n_tasks):
     # Solving is the price of entry; efficiency breaks the ties that solve rate
     # cannot. A model that solves everything in twice par scores 0.5, not 1.0.
     agent_score = solve * (mean_eff if mean_eff is not None else 0.0)
-    return dict(
-        kind="agentic", config=asdict(cfg), tasks=n_tasks, generations=len(results),
-        pass_at_1=solve,
-        agent_score=agent_score,
-        mean_efficiency=mean_eff,
-        mean_par_calls=(sum(r["par_calls"] for r in results if r.get("par_calls"))
-                        / max(1, sum(1 for r in results if r.get("par_calls")))),
-        pass_all_samples=sum(1 for v in by_task.values()
-                             if all(r["passed"] for r in v)) / max(1, len(by_task)),
-        pass_any_sample=sum(1 for v in by_task.values()
-                            if any(r["passed"] for r in v)) / max(1, len(by_task)),
-        wall_seconds=wall,
-        mean_completion_tokens=mean("completion_tokens"),
-        median_completion_tokens=(sorted(r["completion_tokens"] for r in results)[len(results) // 2]
-                                  if results else None),
-        mean_tok_s=mean("tok_s"), mean_ttft=None,
-        aggregate_tok_s=(sum(r["completion_tokens"] for r in results) / wall) if wall else None,
-        truncated=0,
-        errored=sum(1 for r in results if r["stop_reason"] == "error"),
-        # --- agentic-specific ---
-        mean_turns=mean("turns"),
-        mean_tool_calls=mean("tool_calls"),
-        total_tool_calls=total_calls,
-        valid_call_rate=((total_calls - total_failed) / total_calls) if total_calls else None,
-        malformed_args=sum(r["malformed_args"] for r in results),
-        unknown_tools=sum(r["unknown_tools"] for r in results),
-        hit_turn_limit=sum(1 for r in results if r["stop_reason"] == "max_turns"),
-        stalled_no_tool_call=sum(1 for r in results if r["stop_reason"] == "no_tool_call"),
-        by_task={k: sum(1 for r in v if r["passed"]) / len(v) for k, v in sorted(by_task.items())},
-        by_difficulty={d: rate(lambda r, d=d: r["difficulty"] == d)
-                       for d in ("easy", "medium", "hard")},
-    )
+
+    common["kind"] = "agentic"
+    common["pass_at_1"] = solve
+    common["agent_score"] = agent_score
+    common["mean_efficiency"] = mean_eff
+    common["mean_par_calls"] = (
+        sum(r["par_calls"] for r in results if r.get("par_calls"))
+        / max(1, sum(1 for r in results if r.get("par_calls"))))
+    common["truncated"] = 0
+    common["errored"] = sum(1 for r in results if r["stop_reason"] == "error")
+    # --- agentic-specific ---
+    common["mean_turns"] = mean("turns")
+    common["mean_tool_calls"] = mean("tool_calls")
+    common["total_tool_calls"] = total_calls
+    common["valid_call_rate"] = ((total_calls - total_failed) / total_calls) \
+        if total_calls else None
+    common["malformed_args"] = sum(r["malformed_args"] for r in results)
+    common["unknown_tools"] = sum(r["unknown_tools"] for r in results)
+    common["hit_turn_limit"] = sum(1 for r in results if r["stop_reason"] == "max_turns")
+    common["stalled_no_tool_call"] = sum(1 for r in results
+                                        if r["stop_reason"] == "no_tool_call")
+    return common
 
 
 def validate(tasks):

--- a/benchkit/cli.py
+++ b/benchkit/cli.py
@@ -130,9 +130,9 @@ def cmd_run(args):
         print(f"agent score            {summary['agent_score'] * 100:.1f}   "
               f"(solve {summary['pass_at_1'] * 100:.1f} % x efficiency "
               f"{(summary['mean_efficiency'] or 0) * 100:.1f} %)")
-        print(f"mean calls vs par      {summary['mean_tool_calls']:.1f} vs "
-              f"{summary['mean_par_calls']:.1f}")
-        print(f"mean turns / calls     {summary['mean_turns']:.1f} / {summary['mean_tool_calls']:.1f}")
+        print(f"mean calls vs par      {summary['mean_tool_calls'] or 0:.1f} vs "
+              f"{summary['mean_par_calls'] or 0:.1f}")
+        print(f"mean turns / calls     {summary['mean_turns'] or 0:.1f} / {summary['mean_tool_calls'] or 0:.1f}")
         print(f"valid tool-call rate   {(summary['valid_call_rate'] or 0) * 100:.1f} %")
         print(f"malformed / unknown    {summary['malformed_args']} / {summary['unknown_tools']}")
         print(f"turn-limit / stalled   {summary['hit_turn_limit']} / {summary['stalled_no_tool_call']}")
@@ -196,8 +196,11 @@ def cmd_compare(args):
                 print(f"{line}  ({p})", flush=True)
     finally:
         if original and args.restore:
-            print(f"\nrestoring {original}")
-            serving.swap_to(original)
+            try:
+                print(f"\nrestoring {original}")
+                serving.swap_to(original)
+            except Exception as e:  # noqa: BLE001 — log the failure, never mask the original
+                print(f"WARNING: could not restore {original}: {e}", file=sys.stderr)
 
     md = report.build([report.load(p) for p in paths], title=args.title,
                       question=args.question)

--- a/benchkit/cli.py
+++ b/benchkit/cli.py
@@ -245,7 +245,8 @@ def _sweep_harness(args, setup):
     # always pointed at it rather than at its own configured providers.
     endpoint = args.endpoint or args.base_url
     provider, model = _sweep_model(args, setup)
-    h = H.get(setup.harness, provider=provider, model=model, base_url=endpoint)
+    h = H.get(setup.harness,
+              H.HarnessConfig(provider=provider, model=model, base_url=endpoint))
     ok, detail = h.available()
     if not ok:
         raise SystemExit(f"harness {h.name!r} is not usable here: {detail}")
@@ -381,7 +382,7 @@ def _harness_pick(args, endpoint):
     """Which model to benchmark, resolved from the user's own harness config."""
     from benchkit import harness as H
     from benchkit.harness import models as hmodels
-    probe = H.get(args.harness, **_endpoint_kw(endpoint))
+    probe = H.get(args.harness, H.HarnessConfig(base_url=endpoint))
     entries = [] if endpoint else hmodels.catalogue(probe)
     spec = args.model or os.environ.get("BENCH_HARNESS_MODEL") or ""
     if spec:
@@ -427,8 +428,8 @@ def _harness_run(args, endpoint):
     from benchkit.harness import runner as hrunner
 
     provider, model = _harness_pick(args, endpoint)
-    h = H.get(args.harness, provider=provider, model=model,
-              **_endpoint_kw(endpoint))
+    h = H.get(args.harness,
+              H.HarnessConfig(provider=provider, model=model, base_url=endpoint))
     tasks = get(args.suite)
     if kind(args.suite) != "agentic":
         raise SystemExit("harness runs need an agentic suite "
@@ -452,18 +453,6 @@ def _harness_run(args, endpoint):
     _print_harness_summary(h, summary)
     print(f"\nwritten to {out}")
     return 0
-
-
-def _endpoint_kw(endpoint):
-    """An explicit endpoint is opt-in; all three harnesses accept one.
-
-    Every adapter points its tool at a throwaway config for the run rather than
-    editing the user's — opencode via OPENCODE_CONFIG, claude-code via
-    CLAUDE_CONFIG_DIR, pi via a staged catalogue behind PI_CODING_AGENT_DIR.
-    """
-    if not endpoint:
-        return {}
-    return {"base_url": endpoint}
 
 
 def cmd_configs(args):

--- a/benchkit/cli.py
+++ b/benchkit/cli.py
@@ -348,50 +348,52 @@ def cmd_harness(args):
     and credentials, so anyone can run this benchmark against the models they
     already use, without editing their editor's config.
     """
+    if args.harness_cmd == "list":
+        _harness_list()
+        return 0
+    if args.harness_cmd == "models":
+        _harness_models(args)
+        return 0
+    endpoint = args.endpoint or os.environ.get("BENCH_HARNESS_ENDPOINT") or None
+    return _harness_run(args, endpoint)
+
+
+def _harness_list():
+    from benchkit import harness as H
+    for name in H.HARNESSES:
+        ok, detail = H.get(name).probe()
+        print(f"{name:<12} {'ok     ' if ok else 'MISSING'} {detail}")
+
+
+def _harness_models(args):
     from benchkit import harness as H
     from benchkit.harness import models as hmodels
-    from benchkit.harness import runner as hrunner
+    names = [args.harness] if args.harness_explicit else list(H.HARNESSES)
+    for name in names:
+        probe = H.get(name)
+        ok, detail = probe.probe()
+        print(f"\n{name}: {detail}")
+        for provider, model in hmodels.catalogue(probe):
+            print(f"  {hmodels.spec(provider, model)}")
 
-    if args.harness_cmd == "list":
-        for name in H.HARNESSES:
-            ok, detail = H.get(name).probe()
-            print(f"{name:<12} {'ok     ' if ok else 'MISSING'} {detail}")
-        return 0
 
-    endpoint = args.endpoint or os.environ.get("BENCH_HARNESS_ENDPOINT") or None
-
-    if args.harness_cmd == "models":
-        names = [args.harness] if args.harness_explicit else list(H.HARNESSES)
-        for name in names:
-            probe = H.get(name)
-            ok, detail = probe.probe()
-            print(f"\n{name}: {detail}")
-            for provider, model in hmodels.catalogue(probe):
-                print(f"  {hmodels.spec(provider, model)}")
-        return 0
-
-    # --- which model, from the user's own setup --------------------------
+def _harness_pick(args, endpoint):
+    """Which model to benchmark, resolved from the user's own harness config."""
+    from benchkit import harness as H
+    from benchkit.harness import models as hmodels
     probe = H.get(args.harness, **_endpoint_kw(endpoint))
     entries = [] if endpoint else hmodels.catalogue(probe)
     spec = args.model or os.environ.get("BENCH_HARNESS_MODEL") or ""
     if spec:
-        provider, model = hmodels.resolve(spec, entries, provider=args.provider)
-    elif endpoint:
+        return hmodels.resolve(spec, entries, provider=args.provider)
+    if endpoint:
         raise SystemExit("--endpoint needs --model <id served by that endpoint>")
-    else:
-        provider, model = hmodels.pick(args.harness, entries)
+    return hmodels.pick(args.harness, entries)
 
-    h = H.get(args.harness, provider=provider, model=model,
-              **_endpoint_kw(endpoint))
-    tasks = get(args.suite)
-    if kind(args.suite) != "agentic":
-        raise SystemExit("harness runs need an agentic suite "
-                         "(agentic, agentic-hard, agentic-all)")
-    ok, detail = h.available()
-    if not ok:
-        raise SystemExit(f"harness {h.name!r} is not usable here: {detail}")
 
-    cfg = runner.Config(base_url=endpoint or "(harness)", model=h.model_spec,
+def _harness_config(args, h, base_url):
+    """The Config one harness run records, label included."""
+    cfg = runner.Config(base_url=base_url, model=h.model_spec,
                         label=args.label, thinking=args.thinking, max_tokens=0,
                         samples=args.samples, concurrency=args.concurrency,
                         test_timeout=args.test_timeout)
@@ -401,17 +403,10 @@ def cmd_harness(args):
         # harness alone would overwrite one with the other.
         cfg.label = (f"{h.name} {_slug(str(h.model_spec))} "
                      f"think-{'ON' if args.thinking else 'OFF'}")
-    print(f"harness={h.name}  {detail}\nsuite={args.suite} ({len(tasks)} tasks)  "
-          f"{cfg.label}  samples={cfg.samples} concurrency={cfg.concurrency}\n", flush=True)
+    return cfg
 
-    summary, results = hrunner.run(h, tasks, cfg, on_result=_print_agentic,
-                                   timeout=args.timeout, keep_dirs=args.keep_dirs)
-    out = args.out or os.path.join(RESULTS, _stamp(), f"{_slug(cfg.label)}.json")
-    out = _ensure_unique_path(out)
-    os.makedirs(os.path.dirname(out), exist_ok=True)
-    with open(out, "w") as f:
-        json.dump(dict(summary=summary, results=results), f, indent=2)
 
+def _print_harness_summary(h, summary):
     print("\n" + "=" * 64)
     print(f"harness / model        {h.name} / {h.model_spec}")
     print(f"agent score            {summary['agent_score'] * 100:.1f}   "
@@ -425,6 +420,36 @@ def cmd_harness(args):
     print(f"valid tool-call rate   {(summary['valid_call_rate'] or 0) * 100:.1f} %")
     print(f"wall                   {summary['wall_seconds']:.0f} s")
     print("=" * 64)
+
+
+def _harness_run(args, endpoint):
+    from benchkit import harness as H
+    from benchkit.harness import runner as hrunner
+
+    provider, model = _harness_pick(args, endpoint)
+    h = H.get(args.harness, provider=provider, model=model,
+              **_endpoint_kw(endpoint))
+    tasks = get(args.suite)
+    if kind(args.suite) != "agentic":
+        raise SystemExit("harness runs need an agentic suite "
+                         "(agentic, agentic-hard, agentic-all)")
+    ok, detail = h.available()
+    if not ok:
+        raise SystemExit(f"harness {h.name!r} is not usable here: {detail}")
+
+    cfg = _harness_config(args, h, endpoint or "(harness)")
+    print(f"harness={h.name}  {detail}\nsuite={args.suite} ({len(tasks)} tasks)  "
+          f"{cfg.label}  samples={cfg.samples} concurrency={cfg.concurrency}\n", flush=True)
+
+    summary, results = hrunner.run(h, tasks, cfg, on_result=_print_agentic,
+                                   timeout=args.timeout, keep_dirs=args.keep_dirs)
+    out = args.out or os.path.join(RESULTS, _stamp(), f"{_slug(cfg.label)}.json")
+    out = _ensure_unique_path(out)
+    os.makedirs(os.path.dirname(out), exist_ok=True)
+    with open(out, "w") as f:
+        json.dump(dict(summary=summary, results=results), f, indent=2)
+
+    _print_harness_summary(h, summary)
     print(f"\nwritten to {out}")
     return 0
 
@@ -504,31 +529,33 @@ def _ensure_unique_path(path: str) -> str:
         i += 1
 
 
-def main(argv=None):
-    p = argparse.ArgumentParser(prog="bench", description=__doc__)
-    sub = p.add_subparsers(dest="cmd", required=True)
+def _common_args(sp):
+    sp.add_argument("--suite", default="all", choices=list(SUITES))
+    sp.add_argument("--base-url", default=os.environ.get("BENCH_BASE_URL",
+                                                         "http://localhost:8001/v1"))
+    sp.add_argument("--model", default=os.environ.get("BENCH_MODEL", "montimage-dgx-spark"),
+                    help="model name to send in the request (the served alias)")
+    sp.add_argument("--samples", type=int, default=2)
+    sp.add_argument("--concurrency", type=int, default=4)
+    sp.add_argument("--test-timeout", type=int, default=60)
 
-    def common(sp):
-        sp.add_argument("--suite", default="all", choices=list(SUITES))
-        sp.add_argument("--base-url", default=os.environ.get("BENCH_BASE_URL",
-                                                             "http://localhost:8001/v1"))
-        sp.add_argument("--model", default=os.environ.get("BENCH_MODEL", "montimage-dgx-spark"),
-                        help="model name to send in the request (the served alias)")
-        sp.add_argument("--samples", type=int, default=2)
-        sp.add_argument("--concurrency", type=int, default=4)
-        sp.add_argument("--test-timeout", type=int, default=60)
 
+def _parser_suites(sub):
     s = sub.add_parser("suites", help="list the available suites")
     s.add_argument("-v", "--verbose", action="store_true")
     s.set_defaults(func=cmd_suites)
 
+
+def _parser_validate(sub):
     s = sub.add_parser("validate", help="prove the hidden tests are passable")
     s.add_argument("--suite", default="all", choices=list(SUITES))
     s.add_argument("--test-timeout", type=int, default=120)
     s.set_defaults(func=cmd_validate)
 
+
+def _parser_run(sub):
     s = sub.add_parser("run", help="run a suite against an endpoint")
-    common(s)
+    _common_args(s)
     s.add_argument("--thinking", action="store_true", help="enable the model's reasoning block")
     s.add_argument("--max-tokens", type=int, default=6000)
     s.add_argument("--label", default="", help="human name for this run, used in the report")
@@ -538,6 +565,8 @@ def main(argv=None):
                    help="agentic suite: tool-calling turns before the task is abandoned")
     s.set_defaults(func=cmd_run)
 
+
+def _parser_report(sub):
     s = sub.add_parser("report", help="build a Markdown report from result files")
     s.add_argument("results", nargs="+")
     s.add_argument("--title", default="Benchmark report")
@@ -552,8 +581,10 @@ def main(argv=None):
     s.add_argument("--out")
     s.set_defaults(func=cmd_report)
 
+
+def _parser_compare(sub):
     s = sub.add_parser("compare", help="swap the local vLLM between models and report (DGX box only)")
-    common(s)
+    _common_args(s)
     s.add_argument("models", nargs="+", help="Hugging Face model ids to serve in turn")
     s.add_argument("--title", default="Model comparison")
     s.add_argument("--question")
@@ -570,10 +601,12 @@ def main(argv=None):
                    help="skip the restart confirmation prompt")
     s.set_defaults(func=cmd_compare)
 
+
+def _parser_sweep(sub):
     s = sub.add_parser("sweep",
                        help="sweep an explicit setup matrix (config x harness x "
                             "thinking) and rank the setups")
-    common(s)
+    _common_args(s)
     s.add_argument("--setup", dest="setups", action="append", default=[],
                    metavar="config=...,harness=...,model=...,thinking=...",
                    help="one setup, repeatable. Keys: config (a `bench configs` "
@@ -602,6 +635,8 @@ def main(argv=None):
                    help="print the matrix and the restart plan, run nothing")
     s.set_defaults(func=cmd_sweep)
 
+
+def _parser_harness(sub):
     s = sub.add_parser("harness",
                        help="run a suite through a real coding harness (opencode, pi, ...)")
     s.add_argument("harness_cmd", nargs="?", default="run",
@@ -631,9 +666,13 @@ def main(argv=None):
                    help="leave each task's working directory on disk for inspection")
     s.set_defaults(func=cmd_harness)
 
+
+def _parser_configs(sub):
     s = sub.add_parser("configs", help="list known-good serving configs")
     s.set_defaults(func=cmd_configs)
 
+
+def _parser_apply(sub):
     s = sub.add_parser("apply", help="install a known-good config as the active launcher")
     s.add_argument("name", help="config name from `bench configs`")
     s.add_argument("--restart", action="store_true",
@@ -642,8 +681,25 @@ def main(argv=None):
                    help="skip the restart confirmation prompt")
     s.set_defaults(func=cmd_apply)
 
+
+def _build_parser():
+    p = argparse.ArgumentParser(prog="bench", description=__doc__)
+    sub = p.add_subparsers(dest="cmd", required=True)
+    _parser_suites(sub)
+    _parser_validate(sub)
+    _parser_run(sub)
+    _parser_report(sub)
+    _parser_compare(sub)
+    _parser_sweep(sub)
+    _parser_harness(sub)
+    _parser_configs(sub)
+    _parser_apply(sub)
+    return p
+
+
+def main(argv=None):
     argv = sys.argv[1:] if argv is None else list(argv)
-    args = p.parse_args(argv)
+    args = _build_parser().parse_args(argv)
     # `bench harness models` lists every installed harness; naming one narrows
     # it. argparse cannot tell a default from an explicit `--harness pi`.
     args.harness_explicit = any(a == "--harness" or a.startswith("--harness=")

--- a/benchkit/harness/__init__.py
+++ b/benchkit/harness/__init__.py
@@ -2,10 +2,11 @@
 
 See benchkit/harness/base.py for why this exists and ROADMAP.md for what is next.
 """
-__all__ = ["Harness", "HarnessResult", "run_task", "PiHarness", "OpenCodeHarness",
-           "ClaudeCodeHarness", "HARNESSES", "get"]
+__all__ = ["Harness", "HarnessConfig", "HarnessResult", "run_task", "PiHarness",
+           "OpenCodeHarness", "ClaudeCodeHarness", "HARNESSES", "get"]
 
-from .base import Harness as Harness, HarnessResult as HarnessResult, run_task as run_task
+from .base import (Harness as Harness, HarnessConfig as HarnessConfig,
+                   HarnessResult as HarnessResult, run_task as run_task)
 from .pi import PiHarness
 from .opencode import OpenCodeHarness
 from .claudecode import ClaudeCodeHarness
@@ -14,7 +15,7 @@ HARNESSES = {"pi": PiHarness, "opencode": OpenCodeHarness,
               "claude-code": ClaudeCodeHarness}
 
 
-def get(name, **kw):
+def get(name, cfg=None, **kw):
     if name not in HARNESSES:
         raise SystemExit(f"unknown harness {name!r}; have: {', '.join(HARNESSES)}")
-    return HARNESSES[name](**kw)
+    return HARNESSES[name](cfg, **kw)

--- a/benchkit/harness/base.py
+++ b/benchkit/harness/base.py
@@ -34,6 +34,22 @@ class HarnessResult:
     raw_log: str = ""
 
 
+@dataclass(frozen=True)
+class HarnessConfig:
+    """How a run reaches its model: the fields every harness adapter shares.
+
+    One object instead of seven constructor kwargs, so each adapter's __init__
+    carries only what is genuinely its own — claude-code's tool pinning,
+    opencode's variant, pi's agent directory.
+    """
+    provider: str | None = None
+    model: str | None = None
+    base_url: str | None = None
+    binary: str | None = None
+    api_key: str | None = None
+    extra_args: tuple[str, ...] = ()
+
+
 class Harness:
     """Run a prompt against a real directory and leave the result on disk."""
 

--- a/benchkit/harness/base.py
+++ b/benchkit/harness/base.py
@@ -16,7 +16,7 @@ import tempfile
 import time
 from dataclasses import dataclass, field
 
-from ..agentic.env import Workspace
+from ..agentic.env import Workspace, materialise
 
 
 @dataclass
@@ -85,11 +85,7 @@ def run_task(harness, task, sample, timeout=900, thinking=False, keep_dir=False)
     container = tempfile.mkdtemp(prefix=f"benchkit-{harness.name}-")
     workdir = harness.prepare(container)
     try:
-        for path, body in task["files"].items():
-            full = os.path.join(workdir, path)
-            os.makedirs(os.path.dirname(full) or workdir, exist_ok=True)
-            with open(full, "w") as f:
-                f.write(body)
+        materialise(task["files"], workdir)
 
         t0 = time.perf_counter()
         hr = harness.run(workdir, task["prompt"], timeout=timeout, thinking=thinking)

--- a/benchkit/harness/claudecode.py
+++ b/benchkit/harness/claudecode.py
@@ -287,17 +287,20 @@ def _api_root(url):
     return url[:-3].rstrip("/") if url.endswith("/v1") else url
 
 
-def _claudecode_handler(ev, res, _state):
+def _claudecode_handler(ev, res, state):
     """Handle one Claude Code event. Mutates *res* in place."""
     t = ev.get("type")
     if t == "assistant":
-        _state["assistant_count"] += 1
         msg = ev.get("message") or {}
+        state.setdefault("assistant_msgs", set()).add(msg.get("id"))
         for block in msg.get("content") or []:
             if isinstance(block, dict) and block.get("type") == "tool_use":
+                # one message is emitted once per content block, all sharing
+                # an id; dedupe on the tool_use id rather than the message
+                seen = state.setdefault("seen_calls", set())
                 tid = block.get("id")
-                if tid not in _state["seen_calls"]:
-                    _state["seen_calls"].add(tid)
+                if tid not in seen:
+                    seen.add(tid)
                     res.tool_calls += 1
                     res.trace.append(block.get("name", "?"))
     elif t == "user":
@@ -325,10 +328,12 @@ def _claudecode_handler(ev, res, _state):
             res.error = res.error or str(ev.get("result") or "error")[:200]
 
 
+def _claudecode_finalize(res, state):
+    """A stream cut off before its result event still has the assistant turns."""
+    if not res.turns:
+        res.turns = len(state.get("assistant_msgs", ()))
+
+
 def parse_events(stdout):
     """Fold Claude Code's stream-json event stream into a HarnessResult."""
-    _state = {"seen_calls": set(), "assistant_count": 0}
-    res = _parse_events(stdout, lambda ev, r: _claudecode_handler(ev, r, _state))
-    if not res.turns:
-        res.turns = _state["assistant_count"]
-    return res
+    return _parse_events(stdout, _claudecode_handler, _claudecode_finalize)

--- a/benchkit/harness/claudecode.py
+++ b/benchkit/harness/claudecode.py
@@ -65,7 +65,7 @@ import shutil
 import subprocess
 import urllib.request
 
-from .base import Harness, HarnessResult
+from .base import Harness, HarnessConfig, HarnessResult
 from .events import parse_events as _parse_events
 
 #: Built-in tools the model is allowed. Deliberately excludes Task/Workflow
@@ -92,21 +92,20 @@ class ClaudeCodeHarness(Harness):
 
     _config_home = None
 
-    def __init__(self, provider=None, model=None,
-                 base_url=None, binary="claude", api_key="sk-local",
-                 tools=DEFAULT_TOOLS, effort=None, extra_args=()):
+    def __init__(self, cfg=None, *, tools=DEFAULT_TOOLS, effort=None):
         # `provider` exists only so the shared CLI flag is accepted; Claude Code
         # has no provider concept for a custom base URL.
-        self.provider = provider
-        self.model = model
+        c = cfg or HarnessConfig()
+        self.provider = c.provider
+        self.model = c.model
         # No endpoint means "use the install as the user has it": their auth,
         # their default base URL. Only an explicit one is injected.
-        self.base_url = _api_root(base_url) if base_url else None
-        self.binary = binary
-        self.api_key = api_key
+        self.base_url = _api_root(c.base_url) if c.base_url else None
+        self.binary = c.binary or "claude"
+        self.api_key = c.api_key or "sk-local"
         self.tools = list(tools)
         self.effort = effort
-        self.extra_args = list(extra_args)
+        self.extra_args = list(c.extra_args)
 
     # --- discovery ------------------------------------------------------
     def _version(self):

--- a/benchkit/harness/claudecode.py
+++ b/benchkit/harness/claudecode.py
@@ -66,6 +66,7 @@ import subprocess
 import urllib.request
 
 from .base import Harness, HarnessResult
+from .events import parse_events as _parse_events
 
 #: Built-in tools the model is allowed. Deliberately excludes Task/Workflow
 #: (subagents, which can reach other models) and WebSearch/WebFetch (outside
@@ -286,61 +287,48 @@ def _api_root(url):
     return url[:-3].rstrip("/") if url.endswith("/v1") else url
 
 
-def parse_events(stdout):
-    """Fold Claude Code's stream-json event stream into a HarnessResult."""
-    res = HarnessResult(raw_log=stdout[-20000:])
-    seen_calls = set()
-    assistant_msgs = set()
-    for line in stdout.splitlines():
-        line = line.strip()
-        if not line.startswith("{"):
-            continue
-        try:
-            ev = json.loads(line)
-        except ValueError:
-            continue
-        t = ev.get("type")
-        if t == "assistant":
-            msg = ev.get("message") or {}
-            assistant_msgs.add(msg.get("id"))
-            for block in msg.get("content") or []:
-                if isinstance(block, dict) and block.get("type") == "tool_use":
-                    # one message is emitted once per content block, all sharing
-                    # an id; dedupe on the tool_use id rather than the message
-                    tid = block.get("id")
-                    if tid in seen_calls:
-                        continue
-                    seen_calls.add(tid)
+def _claudecode_handler(ev, res, _state):
+    """Handle one Claude Code event. Mutates *res* in place."""
+    t = ev.get("type")
+    if t == "assistant":
+        _state["assistant_count"] += 1
+        msg = ev.get("message") or {}
+        for block in msg.get("content") or []:
+            if isinstance(block, dict) and block.get("type") == "tool_use":
+                tid = block.get("id")
+                if tid not in _state["seen_calls"]:
+                    _state["seen_calls"].add(tid)
                     res.tool_calls += 1
                     res.trace.append(block.get("name", "?"))
-        elif t == "user":
-            msg = ev.get("message") or {}
-            for block in msg.get("content") or []:
-                if (isinstance(block, dict) and block.get("type") == "tool_result"
-                        and block.get("is_error")):
-                    res.failed_calls += 1
-        elif t == "result":
-            res.turns = ev.get("num_turns") or res.turns
-            u = ev.get("usage") or {}
-            # cache tokens are prefill too; the input column must stay comparable
-            # with pi's and opencode's, which count every token sent.
-            res.input_tokens += ((u.get("input_tokens") or 0)
-                                 + (u.get("cache_creation_input_tokens") or 0)
-                                 + (u.get("cache_read_input_tokens") or 0))
-            res.output_tokens += u.get("output_tokens") or 0
-            # always 0 on this endpoint — see the module docstring and describe()
-            res.reasoning_tokens += (
-                (u.get("output_tokens_details") or {}).get("thinking_tokens") or 0)
-            if ev.get("subtype") == "success":
-                res.stop_reason = ev.get("stop_reason") or "end_turn"
-            else:
-                res.stop_reason = "error"
-                res.error = str(ev.get("result") or ev.get("subtype") or "error")[:200]
-            if ev.get("is_error"):
-                res.stop_reason = "error"
-                res.error = res.error or str(ev.get("result") or "error")[:200]
+    elif t == "user":
+        msg = ev.get("message") or {}
+        for block in msg.get("content") or []:
+            if (isinstance(block, dict) and block.get("type") == "tool_result"
+                    and block.get("is_error")):
+                res.failed_calls += 1
+    elif t == "result":
+        res.turns = ev.get("num_turns") or res.turns
+        u = ev.get("usage") or {}
+        res.input_tokens += ((u.get("input_tokens") or 0)
+                             + (u.get("cache_creation_input_tokens") or 0)
+                             + (u.get("cache_read_input_tokens") or 0))
+        res.output_tokens += u.get("output_tokens") or 0
+        res.reasoning_tokens += (
+            (u.get("output_tokens_details") or {}).get("thinking_tokens") or 0)
+        if ev.get("subtype") == "success":
+            res.stop_reason = ev.get("stop_reason") or "end_turn"
+        else:
+            res.stop_reason = "error"
+            res.error = str(ev.get("result") or ev.get("subtype") or "error")[:200]
+        if ev.get("is_error"):
+            res.stop_reason = "error"
+            res.error = res.error or str(ev.get("result") or "error")[:200]
+
+
+def parse_events(stdout):
+    """Fold Claude Code's stream-json event stream into a HarnessResult."""
+    _state = {"seen_calls": set(), "assistant_count": 0}
+    res = _parse_events(stdout, lambda ev, r: _claudecode_handler(ev, r, _state))
     if not res.turns:
-        res.turns = len(assistant_msgs)
-    if res.stop_reason == "unknown" and res.turns:
-        res.stop_reason = "finished"
+        res.turns = _state["assistant_count"]
     return res

--- a/benchkit/harness/events.py
+++ b/benchkit/harness/events.py
@@ -1,0 +1,50 @@
+"""Shared skeleton for folding a harness's JSONL event stream into a HarnessResult.
+
+Three adapters (pi, opencode, claude-code) share the same fold-JSONL-into-HarnessResult
+skeleton, differing only in event names and field paths.  This module provides a
+`parse_events` function that takes a per-adapter event map; each adapter's parser
+shrinks to that map plus its own quirks.
+
+Usage::
+
+    def _handle(ev, res):
+        t = ev.get("type")
+        if t == "turn_start":
+            res.turns += 1
+        # ... more event handlers ...
+
+    result = parse_events(stdout, _handle)
+"""
+import json
+
+
+def parse_events(stdout, handler):
+    """Fold a JSONL event stream into a HarnessResult using *handler*.
+
+    *handler* is a callable ``(event_dict, HarnessResult, state) -> None`` that
+    inspects ``event_dict["type"]`` (or any other key) and mutates the result.
+    *state* is a mutable dict shared across all calls, for deduplication and
+    counters that cannot live on the result object.
+
+    Lines that are not valid JSON objects are silently skipped.
+    """
+    res = _make_result(stdout)
+    _state = {}
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line or not line.startswith("{"):
+            continue
+        try:
+            ev = json.loads(line)
+        except ValueError:
+            continue
+        handler(ev, res, _state)
+    if res.stop_reason == "unknown" and res.turns:
+        res.stop_reason = "finished"
+    return res
+
+
+def _make_result(stdout):
+    """Create a HarnessResult with the raw log tail."""
+    from .base import HarnessResult
+    return HarnessResult(raw_log=stdout[-20000:])

--- a/benchkit/harness/events.py
+++ b/benchkit/harness/events.py
@@ -7,7 +7,7 @@ shrinks to that map plus its own quirks.
 
 Usage::
 
-    def _handle(ev, res):
+    def _handle(ev, res, state):
         t = ev.get("type")
         if t == "turn_start":
             res.turns += 1
@@ -18,13 +18,17 @@ Usage::
 import json
 
 
-def parse_events(stdout, handler):
+def parse_events(stdout, handler, finalize=None):
     """Fold a JSONL event stream into a HarnessResult using *handler*.
 
     *handler* is a callable ``(event_dict, HarnessResult, state) -> None`` that
     inspects ``event_dict["type"]`` (or any other key) and mutates the result.
     *state* is a mutable dict shared across all calls, for deduplication and
     counters that cannot live on the result object.
+
+    *finalize*, when given, is ``(HarnessResult, state) -> None`` and runs once
+    after the last event — before this function applies its default stop_reason,
+    so a fallback that fills in *turns* still feeds that default.
 
     Lines that are not valid JSON objects are silently skipped.
     """
@@ -39,6 +43,8 @@ def parse_events(stdout, handler):
         except ValueError:
             continue
         handler(ev, res, _state)
+    if finalize is not None:
+        finalize(res, _state)
     if res.stop_reason == "unknown" and res.turns:
         res.stop_reason = "finished"
     return res

--- a/benchkit/harness/opencode.py
+++ b/benchkit/harness/opencode.py
@@ -34,7 +34,7 @@ import os
 import shutil
 import subprocess
 
-from .base import Harness, HarnessResult
+from .base import Harness, HarnessConfig, HarnessResult
 from .events import parse_events as _parse_events
 
 CONFIG_NAME = "opencode.json"
@@ -48,15 +48,15 @@ class OpenCodeHarness(Harness):
 
     _config_path = None
 
-    def __init__(self, provider=None, model=None, base_url=None,
-                 binary="opencode", variant=None, api_key=None, extra_args=()):
-        self.base_url = base_url or None
-        self.provider = provider or (DEFAULT_ENDPOINT_PROVIDER if self.base_url else None)
-        self.model = model
-        self.binary = binary
+    def __init__(self, cfg=None, *, variant=None):
+        c = cfg or HarnessConfig()
+        self.base_url = c.base_url or None
+        self.provider = c.provider or (DEFAULT_ENDPOINT_PROVIDER if self.base_url else None)
+        self.model = c.model
+        self.binary = c.binary or "opencode"
         self.variant = variant
-        self.api_key = api_key
-        self.extra_args = list(extra_args)
+        self.api_key = c.api_key
+        self.extra_args = list(c.extra_args)
 
     @property
     def uses_endpoint(self):

--- a/benchkit/harness/opencode.py
+++ b/benchkit/harness/opencode.py
@@ -35,6 +35,7 @@ import shutil
 import subprocess
 
 from .base import Harness, HarnessResult
+from .events import parse_events as _parse_events
 
 CONFIG_NAME = "opencode.json"
 
@@ -230,37 +231,30 @@ class OpenCodeHarness(Harness):
         return res
 
 
+def _opencode_handler(ev, res, _state):
+    """Handle one opencode event. Mutates *res* in place."""
+    t = ev.get("type")
+    part = ev.get("part") or {}
+    if t == "step_start":
+        res.turns += 1
+    elif t == "tool_use":
+        res.tool_calls += 1
+        res.trace.append(part.get("tool", "?"))
+        status = (part.get("state") or {}).get("status")
+        if status not in ("completed", "running", "pending", None):
+            res.failed_calls += 1
+    elif t == "step_finish":
+        tok = part.get("tokens") or {}
+        res.input_tokens += tok.get("input") or 0
+        res.output_tokens += tok.get("output") or 0
+        res.reasoning_tokens += tok.get("reasoning") or 0
+        if part.get("reason"):
+            res.stop_reason = part["reason"]
+    elif t == "error":
+        res.error = str(part or ev)[:200]
+        res.stop_reason = "error"
+
+
 def parse_events(stdout):
     """Fold opencode's JSONL event stream into a HarnessResult."""
-    res = HarnessResult(raw_log=stdout[-20000:])
-    for line in stdout.splitlines():
-        line = line.strip()
-        if not line.startswith("{"):
-            continue
-        try:
-            ev = json.loads(line)
-        except ValueError:
-            continue
-        t = ev.get("type")
-        part = ev.get("part") or {}
-        if t == "step_start":
-            res.turns += 1
-        elif t == "tool_use":
-            res.tool_calls += 1
-            res.trace.append(part.get("tool", "?"))
-            status = (part.get("state") or {}).get("status")
-            if status not in ("completed", "running", "pending", None):
-                res.failed_calls += 1
-        elif t == "step_finish":
-            tok = part.get("tokens") or {}
-            res.input_tokens += tok.get("input") or 0
-            res.output_tokens += tok.get("output") or 0
-            res.reasoning_tokens += tok.get("reasoning") or 0
-            if part.get("reason"):
-                res.stop_reason = part["reason"]
-        elif t == "error":
-            res.error = str(part or ev)[:200]
-            res.stop_reason = "error"
-    if res.stop_reason == "unknown" and res.turns:
-        res.stop_reason = "finished"
-    return res
+    return _parse_events(stdout, _opencode_handler)

--- a/benchkit/harness/pi.py
+++ b/benchkit/harness/pi.py
@@ -63,6 +63,7 @@ import subprocess
 import urllib.request
 
 from .base import Harness, HarnessResult
+from .events import parse_events as _parse_events
 
 THINKING_LEVELS = {False: "off", True: "high"}
 
@@ -363,46 +364,39 @@ class PiHarness(Harness):
         return res
 
 
+def _pi_handler(ev, res, _state):
+    """Handle one pi event. Mutates *res* in place."""
+    t = ev.get("type")
+    if t == "turn_start":
+        res.turns += 1
+    elif t == "tool_execution_start":
+        res.tool_calls += 1
+        name = ev.get("toolName", "?")
+        res.trace.append(name)
+        # open_calls was for a start/end correlation that was never completed —
+        # left behind when the skeleton was first written; removed in #32.
+    elif t == "tool_execution_end":
+        if _call_failed(ev):
+            res.failed_calls += 1
+    elif t == "message_end":
+        m = ev.get("message") or {}
+        if m.get("role") == "assistant":
+            u = m.get("usage") or {}
+            res.input_tokens += u.get("input") or 0
+            res.output_tokens += u.get("output") or 0
+            res.reasoning_tokens += u.get("reasoning") or 0
+            if m.get("stopReason"):
+                res.stop_reason = m["stopReason"]
+    elif t == "agent_end":
+        res.stop_reason = ev.get("reason") or res.stop_reason or "agent_end"
+    elif t == "error":
+        res.error = str(ev.get("message") or ev)[:200]
+        res.stop_reason = "error"
+
+
 def parse_events(stdout):
     """Fold pi's JSONL event stream into a HarnessResult."""
-    res = HarnessResult(raw_log=stdout[-20000:])
-    open_calls = {}
-    for line in stdout.splitlines():
-        line = line.strip()
-        if not line or not line.startswith("{"):
-            continue
-        try:
-            ev = json.loads(line)
-        except ValueError:
-            continue
-        t = ev.get("type")
-        if t == "turn_start":
-            res.turns += 1
-        elif t == "tool_execution_start":
-            res.tool_calls += 1
-            name = ev.get("toolName", "?")
-            res.trace.append(name)
-            open_calls[ev.get("toolCallId")] = name
-        elif t == "tool_execution_end":
-            if _call_failed(ev):
-                res.failed_calls += 1
-        elif t == "message_end":
-            m = ev.get("message") or {}
-            if m.get("role") == "assistant":
-                u = m.get("usage") or {}
-                res.input_tokens += u.get("input") or 0
-                res.output_tokens += u.get("output") or 0
-                res.reasoning_tokens += u.get("reasoning") or 0
-                if m.get("stopReason"):
-                    res.stop_reason = m["stopReason"]
-        elif t == "agent_end":
-            res.stop_reason = ev.get("reason") or res.stop_reason or "agent_end"
-        elif t == "error":
-            res.error = str(ev.get("message") or ev)[:200]
-            res.stop_reason = "error"
-    if res.stop_reason == "unknown" and res.turns:
-        res.stop_reason = "finished"
-    return res
+    return _parse_events(stdout, _pi_handler)
 
 
 def _call_failed(ev):

--- a/benchkit/harness/pi.py
+++ b/benchkit/harness/pi.py
@@ -62,7 +62,7 @@ import shutil
 import subprocess
 import urllib.request
 
-from .base import Harness, HarnessResult
+from .base import Harness, HarnessConfig, HarnessResult
 from .events import parse_events as _parse_events
 
 THINKING_LEVELS = {False: "off", True: "high"}
@@ -87,17 +87,17 @@ ENDPOINT_MAX_TOKENS = 16384
 class PiHarness(Harness):
     name = "pi"
 
-    def __init__(self, provider=None, model=None, base_url=None,
-                 binary="pi", agent_dir=None, api_key=None, extra_args=()):
-        self.base_url = base_url or None
-        self.provider = provider or (DEFAULT_ENDPOINT_PROVIDER if self.base_url else None)
-        self.model = model
-        self.binary = binary
+    def __init__(self, cfg=None, *, agent_dir=None):
+        c = cfg or HarnessConfig()
+        self.base_url = c.base_url or None
+        self.provider = c.provider or (DEFAULT_ENDPOINT_PROVIDER if self.base_url else None)
+        self.model = c.model
+        self.binary = c.binary or "pi"
         #: the user's own agent directory. Read for a normal run, and in
         #: endpoint mode not even that — it is never opened for writing.
         self.agent_dir = agent_dir or os.environ.get("PI_CODING_AGENT_DIR")
-        self.api_key = api_key
-        self.extra_args = list(extra_args)
+        self.api_key = c.api_key
+        self.extra_args = list(c.extra_args)
 
     @property
     def uses_endpoint(self):
@@ -359,8 +359,8 @@ class PiHarness(Harness):
         res = parse_events(p.stdout)
         if p.returncode != 0 and not res.error:
             res.stop_reason = "error"
-            res.error = (p.stderr or "").strip().splitlines()[-1:] and \
-                (p.stderr or "").strip().splitlines()[-1][:200] or f"exit {p.returncode}"
+            tail = (p.stderr or "").strip().splitlines()
+            res.error = tail[-1][:200] if tail else f"exit {p.returncode}"
         return res
 
 

--- a/benchkit/report.py
+++ b/benchkit/report.py
@@ -18,8 +18,12 @@ BUILTIN_HARNESS = "built-in loop"
 
 
 def load(path):
-    with open(path) as f:
-        d = json.load(f)
+    """Load a result file, naming the file on any parse failure."""
+    try:
+        with open(path) as f:
+            d = json.load(f)
+    except json.JSONDecodeError as e:
+        raise SystemExit(f"{os.path.basename(path)}: {e}") from None
     d["_path"] = os.path.basename(path)
     return d
 
@@ -54,7 +58,8 @@ def _fmt(v, pct=False, digits=1):
 
 def _chart(title, y_label, categories, values, y_max=None, kind="bar"):
     if y_max is None:
-        y_max = max(values) * 1.15 if values else 1
+        mx = max(values) if values else 0
+        y_max = mx * 1.15 if mx else 1
     cats = ", ".join(f'"{c}"' for c in categories)
     vals = ", ".join(f"{v:.4g}" for v in values)
     return (f"```mermaid\n{BAR}\n"
@@ -412,22 +417,43 @@ def build(runs, title, question=None, verdict=None, notes=None, short_labels=Non
     # A head-to-head across harnesses or thinking modes is the cross-block
     # comparison the ranking exists to forbid, so in a sweep the pair must come
     # from one block -- and if no block holds two runs, there is no pair.
+    # The pair is selected using the *same* key the results table used to bold
+    # the winner, so the disagreement section never compares a pair excluding
+    # the declared winner.
     pool = range(len(S))
     if setups:
         candidates = [idx for idx in _blocks(runs).values() if len(idx) >= 2]
-        pool = max(candidates,
-                   key=lambda idx: max(S[i]["pass_at_1"] for i in idx)) if candidates else []
+        pool = (max(candidates,
+                    key=lambda idx: max(S[i].get("agent_score") if scored
+                                        else S[i]["pass_at_1"] for i in idx))
+                if candidates else [])
     if len(pool) >= 2:
-        order = sorted(pool, key=lambda i: -S[i]["pass_at_1"])[:2]
+        key = "agent_score" if scored else "pass_at_1"
+        order = sorted(pool, key=lambda i: -(S[i].get(key) or S[i][key]))[:2]
         a, b = order
         ta, tb = S[a]["by_task"], S[b]["by_task"]
-        rows = [(t, ta[t], tb.get(t, 0.0)) for t in sorted(ta) if ta[t] != tb.get(t, 0.0)]
+        # Include every task from both runs; tasks only in one run show as "–"
+        all_tasks = sorted(set(ta) | set(tb))
+        rows = []
+        for t in all_tasks:
+            x = ta.get(t)
+            y = tb.get(t)
+            if x is None:
+                rows.append((t, None, y, labels[b]))
+            elif y is None:
+                rows.append((t, x, None, labels[a]))
+            elif x != y:
+                rows.append((t, x, y, labels[a] if x > y else labels[b]))
         if rows:
             out.append(f"## Where they disagree — {labels[a]} vs {labels[b]}\n")
             out.append(f"| Task | {labels[a]} | {labels[b]} | Winner |\n|---|---|---|---|")
-            for t, x, y in rows:
-                out.append(f"| `{t}` | {x*100:.0f} % | {y*100:.0f} % | "
-                           f"{labels[a] if x > y else labels[b]} |")
+            for t, x, y, winner in rows:
+                if x is None:
+                    out.append(f"| `{t}` | – | {y*100:.0f} % | {winner} (not run) |")
+                elif y is None:
+                    out.append(f"| `{t}` | {x*100:.0f} % | – | {winner} (not run) |")
+                else:
+                    out.append(f"| `{t}` | {x*100:.0f} % | {y*100:.0f} % | {winner} |")
             out.append("")
 
     if notes:

--- a/benchkit/report.py
+++ b/benchkit/report.py
@@ -233,67 +233,57 @@ def rank_setups(runs, labels):
     return "\n".join(out)
 
 
-def build(runs, title, question=None, verdict=None, notes=None, short_labels=None,
-          setups=False):
-    """runs: list of loaded result dicts. Returns Markdown source."""
-    labels = [_label(r) for r in runs]
-    short = short_labels or (_setup_short(runs) if setups
-                             else [_short(r, line) for r, line in zip(runs, labels)])
-    S = [r["summary"] for r in runs]
+def _shared(values, short, fmt=str):
+    """One cell for a setting the runs may or may not agree on.
 
-    out = [f"# {title}\n"]
-    if question:
-        out.append(f"**Question.** {question}\n")
-    if verdict:
-        out.append(f"**Verdict.** {verdict}\n")
+    Silently printing run 0's value hides a methodology mismatch, so when the
+    runs disagree the cell names every value in table order instead.
+    """
+    vals = list(values)
+    if all(v == vals[0] for v in vals):
+        return fmt(vals[0]), True
+    return ("mixed — " + ", ".join(f"{fmt(v)} ({short[i]})"
+                                   for i, v in enumerate(vals)), False)
 
-    # --- setup table ---
-    cfg0 = S[0]["config"]
 
-    def _shared(values, fmt=str):
-        """One cell for a setting the runs may or may not agree on.
+def _endpoint(s):
+    # harness runs record "(harness)" as the config base_url; the real endpoint
+    # the adapter dialled lives on the harness block.
+    url = s["config"]["base_url"]
+    if url == "(harness)":
+        url = (s.get("harness") or {}).get("base_url")
+    if not url or url == "(harness)":
+        return None
+    # claude-code dials the Anthropic surface at the root and the others the
+    # OpenAI-compatible /v1 on the same server; compare hosts, not surfaces.
+    return url.rstrip("/").removesuffix("/v1")
 
-        Silently printing run 0's value hides a methodology mismatch, so when the
-        runs disagree the cell names every value in table order instead.
-        """
-        vals = list(values)
-        if all(v == vals[0] for v in vals):
-            return fmt(vals[0]), True
-        return ("mixed — " + ", ".join(f"{fmt(v)} ({short[i]})"
-                                       for i, v in enumerate(vals)), False)
 
-    def _endpoint(s):
-        # harness runs record "(harness)" as the config base_url; the real endpoint
-        # the adapter dialled lives on the harness block.
-        url = s["config"]["base_url"]
-        if url == "(harness)":
-            url = (s.get("harness") or {}).get("base_url")
-        if not url or url == "(harness)":
-            return None
-        # claude-code dials the Anthropic surface at the root and the others the
-        # OpenAI-compatible /v1 on the same server; compare hosts, not surfaces.
-        return url.rstrip("/").removesuffix("/v1")
-
-    # a run that simply did not record its endpoint is not a disagreement about it
-    eps = [_endpoint(s) for s in S]
+def _endpoint_cell(eps, short):
+    """The Setup table's endpoint row: one host when they agree, every host otherwise."""
     known = [(short[i], e) for i, e in enumerate(eps) if e]
     if not known:
-        endpoint = "not recorded"
-    elif all(e == known[0][1] for _, e in known):
+        return "not recorded"
+    if all(e == known[0][1] for _, e in known):
         endpoint = f"`{known[0][1]}`"
         if len(known) < len(eps):
             missing = ", ".join(short[i] for i, e in enumerate(eps) if not e)
             endpoint += f" (not recorded for {missing})"
-    else:
-        endpoint = "mixed — " + ", ".join(f"`{e}` ({n})" for n, e in known)
-    tasks, _ = _shared([s["tasks"] for s in S])
-    conc, conc_same = _shared([s["config"]["concurrency"] for s in S])
-    samples, samples_same = _shared([s["config"]["samples"] for s in S])
-    gens, _ = _shared([s["generations"] for s in S])
+        return endpoint
+    return "mixed — " + ", ".join(f"`{e}` ({n})" for n, e in known)
 
-    out.append("## Setup\n")
+
+def _setup_section(S, short):
+    """The Setup table, plus the sample settings the caveats quote back."""
+    eps = [_endpoint(s) for s in S]
+    tasks, _ = _shared([s["tasks"] for s in S], short)
+    conc, conc_same = _shared([s["config"]["concurrency"] for s in S], short)
+    samples, samples_same = _shared([s["config"]["samples"] for s in S], short)
+    gens, _ = _shared([s["generations"] for s in S], short)
+
+    out = ["## Setup\n"]
     out.append("| | |\n|---|---|")
-    out.append(f"| Endpoint | {endpoint} |")
+    out.append(f"| Endpoint | {_endpoint_cell(eps, short)} |")
     out.append(f"| Tasks | {tasks} |")
     if samples_same:
         out.append(f"| Samples per task | {samples} (⇒ {gens} generations per run) |")
@@ -306,27 +296,31 @@ def build(runs, title, question=None, verdict=None, notes=None, short_labels=Non
                    "Solve rate and tool-call counts are unaffected, but wall-clock is not "
                    "comparable across rows that differ in concurrency, and scores from "
                    "different sample counts carry different noise floors.</sub>\n")
+    return out, samples, samples_same
 
-    # --- results table ---
-    agentic = all(s.get("kind") == "agentic" for s in S)
-    # agentic runs predating oracle-par efficiency carry no agent_score; they can
-    # still be reported, just without the column that ranks them.
-    scored = agentic and all(s.get("agent_score") is not None for s in S)
-    out.append("## Results\n")
-    # rank agentic runs on the agent score; solve rate ties too often to rank on
+
+def _leaders(S, runs, setups, scored):
+    """Which rows the results table bolds: each block's leader in a sweep."""
     if setups:
-        # A sweep spans several harnesses and both thinking modes, so a single
-        # bolded row would be a cross-harness verdict printed directly above the
-        # section explaining that no such verdict exists. Bold each comparable
-        # block's leader instead.
         leaders = set()
         for idx in _blocks(runs).values():
             key = _block_key(S, idx)
             leaders.add(max(idx, key=lambda i, key=key: (S[i].get(key) or 0)))
-    else:
-        leaders = {max(range(len(S)),
-                       key=lambda i: (S[i]["agent_score"] if scored
-                                      else S[i]["pass_at_1"]))}
+        return leaders
+    return {max(range(len(S)),
+                key=lambda i: (S[i]["agent_score"] if scored
+                               else S[i]["pass_at_1"]))}
+
+
+def _results_section(runs, S, labels, setups):
+    """The results table and its footnotes; also whether runs are agentic/scored."""
+    agentic = all(s.get("kind") == "agentic" for s in S)
+    # agentic runs predating oracle-par efficiency carry no agent_score; they can
+    # still be reported, just without the column that ranks them.
+    scored = agentic and all(s.get("agent_score") is not None for s in S)
+    leaders = _leaders(S, runs, setups, scored)
+    out = ["## Results\n"]
+    # rank agentic runs on the agent score; solve rate ties too often to rank on
     if scored:
         out.append("| Run | Agent score | Solved | Efficiency | Mean calls | Par "
                    "| Valid calls | Turn-limit | Wall |\n"
@@ -382,8 +376,11 @@ def build(runs, title, question=None, verdict=None, notes=None, short_labels=Non
                    "different harnesses are not comparable, and neither are the "
                    "charts that follow.</sub>\n")
         out.append(rank_setups(runs, labels))
+    return out, agentic, scored
 
-    # --- charts ---
+
+def _charts_section(S, short, agentic, scored):
+    out = []
     out.append(_chart("Solve rate (%)" if agentic else "pass@1 (%)",
                       "solved %" if agentic else "pass@1 %", short,
                       [s["pass_at_1"] * 100 for s in S], y_max=100))
@@ -401,25 +398,33 @@ def build(runs, title, question=None, verdict=None, notes=None, short_labels=Non
     else:
         out.append(_chart("Mean output tokens per answer", "tokens", short,
                           [s["mean_completion_tokens"] or 0 for s in S]))
+    return out
 
-    # --- accuracy by difficulty, one line per run ---
+
+def _difficulty_section(S, labels):
+    """Accuracy by difficulty, one mermaid line per run."""
     diffs = ["easy", "medium", "hard"]
     lines = "\n".join(
         "    line [" + ", ".join(f"{(s['by_difficulty'].get(d) or 0) * 100:.4g}" for d in diffs) + "]"
         for s in S)
-    out.append("```mermaid\n" + BAR + "\n"
-               '    title "pass@1 by difficulty (%)"\n'
-               '    x-axis ["easy", "medium", "hard"]\n'
-               '    y-axis "pass@1 %" 0 --> 100\n' + lines + "\n```\n")
+    out = ["```mermaid\n" + BAR + "\n"
+           '    title "pass@1 by difficulty (%)"\n'
+           '    x-axis ["easy", "medium", "hard"]\n'
+           '    y-axis "pass@1 %" 0 --> 100\n' + lines + "\n```\n"]
     out.append("<sub>" + " · ".join(f"Line {i+1} = {line}" for i, line in enumerate(labels)) + "</sub>\n")
+    return out
 
-    # --- per-task disagreement between best and runner-up ---
-    # A head-to-head across harnesses or thinking modes is the cross-block
-    # comparison the ranking exists to forbid, so in a sweep the pair must come
-    # from one block -- and if no block holds two runs, there is no pair.
-    # The pair is selected using the *same* key the results table used to bold
-    # the winner, so the disagreement section never compares a pair excluding
-    # the declared winner.
+
+def _disagreement_section(runs, S, labels, setups, scored):
+    """Per-task disagreement between the best run and the runner-up.
+
+    A head-to-head across harnesses or thinking modes is the cross-block
+    comparison the ranking exists to forbid, so in a sweep the pair must come
+    from one block -- and if no block holds two runs, there is no pair.
+    The pair is selected using the *same* key the results table used to bold
+    the winner, so the disagreement section never compares a pair excluding
+    the declared winner.
+    """
     pool = range(len(S))
     if setups:
         candidates = [idx for idx in _blocks(runs).values() if len(idx) >= 2]
@@ -427,40 +432,41 @@ def build(runs, title, question=None, verdict=None, notes=None, short_labels=Non
                     key=lambda idx: max(S[i].get("agent_score") if scored
                                         else S[i]["pass_at_1"] for i in idx))
                 if candidates else [])
-    if len(pool) >= 2:
-        key = "agent_score" if scored else "pass_at_1"
-        order = sorted(pool, key=lambda i: -(S[i].get(key) or S[i][key]))[:2]
-        a, b = order
-        ta, tb = S[a]["by_task"], S[b]["by_task"]
-        # Include every task from both runs; tasks only in one run show as "–"
-        all_tasks = sorted(set(ta) | set(tb))
-        rows = []
-        for t in all_tasks:
-            x = ta.get(t)
-            y = tb.get(t)
-            if x is None:
-                rows.append((t, None, y, labels[b]))
-            elif y is None:
-                rows.append((t, x, None, labels[a]))
-            elif x != y:
-                rows.append((t, x, y, labels[a] if x > y else labels[b]))
-        if rows:
-            out.append(f"## Where they disagree — {labels[a]} vs {labels[b]}\n")
-            out.append(f"| Task | {labels[a]} | {labels[b]} | Winner |\n|---|---|---|---|")
-            for t, x, y, winner in rows:
-                if x is None:
-                    out.append(f"| `{t}` | – | {y*100:.0f} % | {winner} (not run) |")
-                elif y is None:
-                    out.append(f"| `{t}` | {x*100:.0f} % | – | {winner} (not run) |")
-                else:
-                    out.append(f"| `{t}` | {x*100:.0f} % | {y*100:.0f} % | {winner} |")
-            out.append("")
+    if len(pool) < 2:
+        return []
+    key = "agent_score" if scored else "pass_at_1"
+    order = sorted(pool, key=lambda i: -(S[i].get(key) or S[i][key]))[:2]
+    a, b = order
+    ta, tb = S[a]["by_task"], S[b]["by_task"]
+    # Include every task from both runs; tasks only in one run show as "–"
+    all_tasks = sorted(set(ta) | set(tb))
+    rows = []
+    for t in all_tasks:
+        x = ta.get(t)
+        y = tb.get(t)
+        if x is None:
+            rows.append((t, None, y, labels[b]))
+        elif y is None:
+            rows.append((t, x, None, labels[a]))
+        elif x != y:
+            rows.append((t, x, y, labels[a] if x > y else labels[b]))
+    if not rows:
+        return []
+    out = [f"## Where they disagree — {labels[a]} vs {labels[b]}\n"]
+    out.append(f"| Task | {labels[a]} | {labels[b]} | Winner |\n|---|---|---|---|")
+    for t, x, y, winner in rows:
+        if x is None:
+            out.append(f"| `{t}` | – | {y*100:.0f} % | {winner} (not run) |")
+        elif y is None:
+            out.append(f"| `{t}` | {x*100:.0f} % | – | {winner} (not run) |")
+        else:
+            out.append(f"| `{t}` | {x*100:.0f} % | {y*100:.0f} % | {winner} |")
+    out.append("")
+    return out
 
-    if notes:
-        out.append("## Reading the numbers\n")
-        out.append(notes.strip() + "\n")
 
-    out.append("## Caveats\n")
+def _caveats_section(cfg0, samples, samples_same, agentic):
+    out = ["## Caveats\n"]
     if samples_same:
         out.append(f"- {cfg0['samples']} samples per task. Differences under ~8 points are "
                    "noise, not signal.")
@@ -482,8 +488,46 @@ def build(runs, title, question=None, verdict=None, notes=None, short_labels=Non
     else:
         out.append("- A truncated generation counts as a failure; a high `Truncated` column means "
                    "runaway reasoning, which hangs real agents.")
-    out.append("\n## Raw data\n")
+    return out
+
+
+def _raw_data_section(runs, labels):
+    out = ["\n## Raw data\n"]
     for r, line in zip(runs, labels):
         out.append(f"- `{r['_path']}` — {line}")
     out.append("")
+    return out
+
+
+def build(runs, title, question=None, verdict=None, notes=None, short_labels=None,
+          setups=False):
+    """runs: list of loaded result dicts. Returns Markdown source."""
+    labels = [_label(r) for r in runs]
+    short = short_labels or (_setup_short(runs) if setups
+                             else [_short(r, line) for r, line in zip(runs, labels)])
+    S = [r["summary"] for r in runs]
+
+    out = [f"# {title}\n"]
+    if question:
+        out.append(f"**Question.** {question}\n")
+    if verdict:
+        out.append(f"**Verdict.** {verdict}\n")
+    cfg0 = S[0]["config"]
+
+    setup_lines, samples, samples_same = _setup_section(S, short)
+    out.extend(setup_lines)
+
+    result_lines, agentic, scored = _results_section(runs, S, labels, setups)
+    out.extend(result_lines)
+
+    out.extend(_charts_section(S, short, agentic, scored))
+    out.extend(_difficulty_section(S, labels))
+    out.extend(_disagreement_section(runs, S, labels, setups, scored))
+
+    if notes:
+        out.append("## Reading the numbers\n")
+        out.append(notes.strip() + "\n")
+
+    out.extend(_caveats_section(cfg0, samples, samples_same, agentic))
+    out.extend(_raw_data_section(runs, labels))
     return "\n".join(out)

--- a/benchkit/runner.py
+++ b/benchkit/runner.py
@@ -44,11 +44,19 @@ class Config:
     @classmethod
     def from_env(cls, **over):
         e = os.environ.get
+        raw = e("BENCH_THINKING", "").lower()
+        thinking = raw in ("1", "true", "yes", "on")
+        try:
+            max_tokens = int(e("BENCH_MAX_TOKENS", cls.max_tokens))
+        except ValueError:
+            raise SystemExit(
+                f"BENCH_MAX_TOKENS must be an integer, got {e('BENCH_MAX_TOKENS')!r}"
+            ) from None
         c = cls(
             base_url=e("BENCH_BASE_URL", cls.base_url),
             model=e("BENCH_MODEL", cls.model),
-            thinking=e("BENCH_THINKING", "0") not in ("0", "false", "False", ""),
-            max_tokens=int(e("BENCH_MAX_TOKENS", cls.max_tokens)),
+            thinking=thinking,
+            max_tokens=max_tokens,
             samples=int(e("BENCH_SAMPLES", cls.samples)),
             concurrency=int(e("BENCH_CONCURRENCY", cls.concurrency)),
             test_timeout=int(e("BENCH_TEST_TIMEOUT", cls.test_timeout)),
@@ -183,14 +191,19 @@ def run(tasks, cfg, on_result=None, keep_code=False):
     return summarize(results, cfg, wall, len(tasks)), results
 
 
-def summarize(results, cfg, wall, n_tasks):
+def _summarize_common(results, cfg, wall, n_tasks):
+    """Shared scoring logic used by both runner and agentic loop.
+
+    Computes *by_task*, *pass_all_samples*, *pass_any_sample*, the token
+    statistics, and *by_difficulty*.  The caller adds kind-specific fields
+    (pass_at_1, agent_score, tool-call counts, …) on top of the returned dict.
+    """
     by_task = {}
     for r in results:
         by_task.setdefault(r["task"], []).append(r)
-    toks = [r["completion_tokens"] for r in results if r["completion_tokens"]]
-    tps = [r["tok_s"] for r in results if r["tok_s"]]
-    ttfts = [r["ttft"] for r in results if r["ttft"]]
-    n_pass = sum(1 for r in results if r["passed"])
+    toks = [r["completion_tokens"] for r in results if r.get("completion_tokens")]
+    tps = [r["tok_s"] for r in results if r.get("tok_s")]
+    ttfts = [r["ttft"] for r in results if r.get("ttft")]
 
     def rate(pred):
         sel = [r for r in results if pred(r)]
@@ -198,7 +211,6 @@ def summarize(results, cfg, wall, n_tasks):
 
     return dict(
         config=asdict(cfg), tasks=n_tasks, generations=len(results),
-        pass_at_1=n_pass / len(results) if results else 0.0,
         pass_all_samples=sum(1 for v in by_task.values()
                              if all(r["passed"] for r in v)) / max(1, len(by_task)),
         pass_any_sample=sum(1 for v in by_task.values()
@@ -209,11 +221,19 @@ def summarize(results, cfg, wall, n_tasks):
         mean_tok_s=sum(tps) / len(tps) if tps else None,
         aggregate_tok_s=sum(toks) / wall if toks else None,
         mean_ttft=sum(ttfts) / len(ttfts) if ttfts else None,
-        truncated=sum(1 for r in results if r.get("completion_tokens")
-                      and r["completion_tokens"] >= cfg.max_tokens - 2),
-        errored=sum(1 for r in results if str(r.get("error", "")).startswith("generation failed")),
         by_task={k: sum(1 for r in v if r["passed"]) / len(v)
                  for k, v in sorted(by_task.items())},
         by_difficulty={d: rate(lambda r, d=d: r["difficulty"] == d)
                        for d in ("easy", "medium", "hard")},
     )
+
+
+def summarize(results, cfg, wall, n_tasks):
+    common = _summarize_common(results, cfg, wall, n_tasks)
+    n_pass = sum(1 for r in results if r["passed"])
+    common["pass_at_1"] = n_pass / len(results) if results else 0.0
+    common["truncated"] = sum(1 for r in results if r.get("completion_tokens")
+                              and r["completion_tokens"] >= cfg.max_tokens - 2)
+    common["errored"] = sum(1 for r in results
+                            if str(r.get("error", "")).startswith("generation failed"))
+    return common

--- a/tests/test_harness_models.py
+++ b/tests/test_harness_models.py
@@ -11,7 +11,7 @@ import unittest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from benchkit.harness import HARNESSES, get, models  # noqa: E402
+from benchkit.harness import HARNESSES, HarnessConfig, get, models  # noqa: E402
 
 CATALOGUE = [
     ("anthropic", "claude-sonnet-4-5"),
@@ -133,7 +133,7 @@ class TestHarnessDefaults(unittest.TestCase):
 
     def test_pi_accepts_an_endpoint(self):
         """pi used to refuse one outright; it now stages a catalogue instead."""
-        h = get("pi", model="m", base_url="http://localhost:8001/v1")
+        h = get("pi", HarnessConfig(model="m", base_url="http://localhost:8001/v1"))
         self.assertTrue(h.uses_endpoint)
         self.assertEqual(h.base_url, "http://localhost:8001/v1")
         self.assertEqual(h.provider, "benchkit")
@@ -143,15 +143,15 @@ class TestHarnessDefaults(unittest.TestCase):
         """--endpoint is one contract, not three: cli.py passes it blindly."""
         for name in HARNESSES:
             with self.subTest(harness=name):
-                h = get(name, model="m", base_url="http://x/v1")
+                h = get(name, HarnessConfig(model="m", base_url="http://x/v1"))
                 self.assertTrue(h.uses_endpoint)
                 self.assertEqual(_offline_describe(h)["source"], "endpoint")
 
     def test_opencode_injects_config_only_for_an_endpoint(self):
-        h = get("opencode", provider="ollama", model="m")
+        h = get("opencode", HarnessConfig(provider="ollama", model="m"))
         self.assertNotIn("provider", str(h.describe().get("base_url") or ""))
         self.assertEqual(h.model_spec, "ollama/m")
-        e = get("opencode", model="m", base_url="http://x/v1")
+        e = get("opencode", HarnessConfig(model="m", base_url="http://x/v1"))
         self.assertEqual(e.provider, "benchkit")
         self.assertIn("http://x/v1", e._config()["provider"]["benchkit"]
                       ["options"]["baseURL"])

--- a/tests/test_pi_endpoint.py
+++ b/tests/test_pi_endpoint.py
@@ -16,7 +16,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from benchkit.harness import get  # noqa: E402
+from benchkit.harness import HarnessConfig, get  # noqa: E402
 from benchkit.harness.pi import (  # noqa: E402
     CATALOGUE_NAME,
     DEFAULT_ENDPOINT_PROVIDER,
@@ -54,9 +54,9 @@ class PiEndpointCase(unittest.TestCase):
         self.container = os.path.join(self.tmp.name, "container")
         os.makedirs(self.container)
 
-    def harness(self, **kw):
+    def harness(self, cfg=None, **kw):
         kw.setdefault("agent_dir", self.agent_dir)
-        return get("pi", **kw)
+        return get("pi", cfg, **kw)
 
     def staged(self):
         return os.path.join(self.container, STAGED_AGENT_DIR, CATALOGUE_NAME)
@@ -73,7 +73,7 @@ class PiEndpointCase(unittest.TestCase):
 
 class TestEndpointStaging(PiEndpointCase):
     def test_prepare_writes_the_endpoint_provider_into_a_copy(self):
-        h = self.harness(model="served-model", base_url=ENDPOINT)
+        h = self.harness(HarnessConfig(model="served-model", base_url=ENDPOINT))
         workdir = h.prepare(self.container)
 
         catalogue = self.read_json(self.staged())
@@ -87,7 +87,7 @@ class TestEndpointStaging(PiEndpointCase):
 
     def test_no_user_credentials_are_copied_into_the_run(self):
         """Only the injected provider is staged; their apiKeys stay put."""
-        h = self.harness(model="served-model", base_url=ENDPOINT)
+        h = self.harness(HarnessConfig(model="served-model", base_url=ENDPOINT))
         h.prepare(self.container)
         with open(self.staged()) as f:
             body = f.read()
@@ -97,7 +97,7 @@ class TestEndpointStaging(PiEndpointCase):
 
     def test_repeated_prepare_does_not_compound_or_share_state(self):
         """One instance serves every task, and the runner threads them."""
-        h = self.harness(model="served-model", base_url=ENDPOINT)
+        h = self.harness(HarnessConfig(model="served-model", base_url=ENDPOINT))
         first = h.prepare(self.container)
         second_container = os.path.join(self.tmp.name, "container-2")
         os.makedirs(second_container)
@@ -118,12 +118,12 @@ class TestEndpointStaging(PiEndpointCase):
 
     def test_the_users_catalogue_is_never_written(self):
         """The whole reason pi refused an endpoint before: prove it is safe."""
-        h = self.harness(model="served-model", base_url=ENDPOINT)
+        h = self.harness(HarnessConfig(model="served-model", base_url=ENDPOINT))
         h.prepare(self.container)
         self.assert_user_config_untouched()
 
     def test_the_subprocess_is_pointed_at_the_staged_catalogue(self):
-        h = self.harness(model="served-model", base_url=ENDPOINT)
+        h = self.harness(HarnessConfig(model="served-model", base_url=ENDPOINT))
         workdir = h.prepare(self.container)
         env = h._env(h._staged_dir(workdir))
         self.assertEqual(env["PI_CODING_AGENT_DIR"],
@@ -132,7 +132,7 @@ class TestEndpointStaging(PiEndpointCase):
 
     def test_the_injected_provider_is_addressable(self):
         """`--provider benchkit` is only passed if pi would accept it."""
-        h = self.harness(model="served-model", base_url=ENDPOINT)
+        h = self.harness(HarnessConfig(model="served-model", base_url=ENDPOINT))
         workdir = h.prepare(self.container)
         staged = h._staged_dir(workdir)
         self.assertTrue(h._provider_addressable(staged))
@@ -146,7 +146,7 @@ class TestEndpointStaging(PiEndpointCase):
         """Endpoint mode must work on a machine with no pi config at all."""
         empty = os.path.join(self.tmp.name, "nothing-here")
         os.makedirs(empty)
-        h = get("pi", model="served-model", base_url=ENDPOINT, agent_dir=empty)
+        h = get("pi", HarnessConfig(model="served-model", base_url=ENDPOINT), agent_dir=empty)
         h.prepare(self.container)
         providers = self.read_json(self.staged())["providers"]
         self.assertEqual(list(providers), [DEFAULT_ENDPOINT_PROVIDER])
@@ -155,13 +155,14 @@ class TestEndpointStaging(PiEndpointCase):
     def test_nothing_is_created_in_the_users_agent_dir(self):
         """Not one new file: the run has no business writing there at all."""
         before = sorted(os.listdir(self.agent_dir))
-        h = self.harness(model="served-model", base_url=ENDPOINT)
+        h = self.harness(HarnessConfig(model="served-model", base_url=ENDPOINT))
         h.prepare(self.container)
         self.assertEqual(sorted(os.listdir(self.agent_dir)), before)
         self.assert_user_config_untouched()
 
     def test_an_explicit_api_key_reaches_the_staged_provider(self):
-        h = self.harness(model="served-model", base_url=ENDPOINT, api_key="k")
+        h = self.harness(HarnessConfig(model="served-model", base_url=ENDPOINT,
+                                       api_key="k"))
         h.prepare(self.container)
         providers = self.read_json(self.staged())["providers"]
         self.assertEqual(providers[DEFAULT_ENDPOINT_PROVIDER]["apiKey"], "k")
@@ -171,7 +172,7 @@ class TestWithoutAnEndpoint(PiEndpointCase):
     """No --endpoint means nothing is staged and nothing is redirected."""
 
     def test_prepare_stages_nothing(self):
-        h = self.harness(provider="local-dgx", model="montimage-dgx-spark")
+        h = self.harness(HarnessConfig(provider="local-dgx", model="montimage-dgx-spark"))
         workdir = h.prepare(self.container)
         self.assertEqual(workdir, self.container)
         self.assertFalse(os.path.exists(
@@ -179,14 +180,14 @@ class TestWithoutAnEndpoint(PiEndpointCase):
         self.assert_user_config_untouched()
 
     def test_the_users_own_agent_dir_is_still_used(self):
-        h = self.harness(provider="local-dgx", model="montimage-dgx-spark")
+        h = self.harness(HarnessConfig(provider="local-dgx", model="montimage-dgx-spark"))
         h.prepare(self.container)
         self.assertEqual(h.agent_dir, self.agent_dir)
         self.assertEqual(h._env()["PI_CODING_AGENT_DIR"], self.agent_dir)
         self.assertEqual(h._catalogue_path(), self.catalogue)
 
     def test_the_users_catalogue_still_resolves_the_model(self):
-        h = self.harness(provider="local-dgx", model="montimage-dgx-spark")
+        h = self.harness(HarnessConfig(provider="local-dgx", model="montimage-dgx-spark"))
         self.assertEqual(h._catalogue_models(),
                          [("local-dgx", "montimage-dgx-spark")])
         self.assertFalse(h.uses_endpoint)
@@ -235,13 +236,13 @@ class TestEndpointAvailability(PiEndpointCase):
         self.url = f"http://127.0.0.1:{self.server.server_port}/v1"
 
     def test_a_served_model_is_accepted(self):
-        h = self.harness(model="served-model", base_url=self.url)
+        h = self.harness(HarnessConfig(model="served-model", base_url=self.url))
         ok, detail = h.available()
         self.assertTrue(ok, detail)
         self.assertIn(self.url, detail)
 
     def test_a_model_the_endpoint_does_not_serve_is_named(self):
-        h = self.harness(model="not-there", base_url=self.url)
+        h = self.harness(HarnessConfig(model="not-there", base_url=self.url))
         ok, detail = h.available()
         self.assertFalse(ok)
         self.assertIn("not-there", detail)
@@ -249,20 +250,20 @@ class TestEndpointAvailability(PiEndpointCase):
 
     def test_the_catalogue_is_not_consulted_in_endpoint_mode(self):
         """`local-dgx/montimage-dgx-spark` is in the fixture and irrelevant here."""
-        h = self.harness(model="montimage-dgx-spark", base_url=self.url)
+        h = self.harness(HarnessConfig(model="montimage-dgx-spark", base_url=self.url))
         ok, detail = h.available()
         self.assertFalse(ok, "the user's catalogue must not vouch for an endpoint")
         self.assertIn("not served at", detail)
 
     def test_an_unreachable_endpoint_says_so(self):
-        h = self.harness(model="served-model", base_url="http://127.0.0.1:1/v1")
+        h = self.harness(HarnessConfig(model="served-model", base_url="http://127.0.0.1:1/v1"))
         ok, detail = h.available()
         self.assertFalse(ok)
         self.assertIn("unreachable", detail)
 
     def test_endpoint_mode_enumerates_nothing(self):
         """The injected provider exists for one run; there is no list to show."""
-        h = self.harness(model="served-model", base_url=self.url)
+        h = self.harness(HarnessConfig(model="served-model", base_url=self.url))
         self.assertEqual(h.list_models(), [])
 
 


### PR DESCRIPTION
## Summary
Completes the two remaining Phase P3 issues (#33, #34) plus lands previously-stranded dedup refactors.

Closes #33
Closes #34

### Commits
1. `refactor: land stranded P3 dedup refactors (#29, #30, #31)` — recovers uncommitted implementations of already-closed issues: summarize() merged into `_summarize_common`, `agentic/env.materialise()` helper, shared `harness/events.py` parse_events skeleton.
2. `refactor: split oversized functions (#33)` — `report.build` → 11 helpers, `cli.main` → parser helpers, `cli.cmd_harness` → 6 helpers, `loop.run_task` → 4 helpers (max function length now 50 lines).
3. `fix(review): …` ×2 — claudecode handler arity crash (TypeError on every run) + finalize hook restoring turn/stop_reason semantics; `_summarize_common` zero-row token-stat drift.
4. `refactor(harness): dataclass config + stderr parity (#34)` — frozen `HarnessConfig` dataclass; pi.py stderr extraction byte-identical to opencode.py; dead `_endpoint_kw` removed; 21 call sites migrated through `get()`.

## Test plan
- [x] `./bench validate` 28/28
- [x] `./bench validate --suite agentic-all` 16/16
- [x] pytest 215 passed (+54 subtests)
- [x] ruff + mypy clean; CI green

## Review
Two autonomous review-fix cycles ran: PASS with 2 regression-class fixes (cycle 1) and a clean confirmation pass (cycle 2).