### PR TITLE
perf(agentic): dedupe changed_lines diff and lock par memo (#41)

### DIFF
--- a/benchkit/agentic/loop.py
+++ b/benchkit/agentic/loop.py
@@ -7,6 +7,7 @@ by flailing through twenty calls is not the same as one that solves it in four.
 """
 import concurrent.futures as cf
 import json
+import threading
 import time
 
 from ..runner import _summarize_common
@@ -16,6 +17,7 @@ from .tools import TOOLS, SYSTEM
 MAX_TURNS = 25
 
 _PAR_CACHE = {}
+_PAR_LOCK = threading.Lock()
 
 
 def par_calls(task):
@@ -24,15 +26,20 @@ def par_calls(task):
     This is the suite's ruler for effort. Two models that both solve everything
     are not equal, and par turns "how much flailing" into a number that does not
     depend on the model, the prompt, or the wall clock.
+
+    Samples run concurrently in a thread pool, so the memo is lock-guarded
+    (double-checked) and the oracle runs exactly once per task.
     """
     tid = task["id"]
     if tid not in _PAR_CACHE:
-        ws = Workspace(task["files"])
-        try:
-            task["oracle"](ws)
-            _PAR_CACHE[tid] = max(1, len(ws.calls))
-        except Exception:  # noqa: BLE001 — a broken oracle is caught by `bench validate`
-            _PAR_CACHE[tid] = None
+        with _PAR_LOCK:
+            if tid not in _PAR_CACHE:
+                ws = Workspace(task["files"])
+                try:
+                    task["oracle"](ws)
+                    _PAR_CACHE[tid] = max(1, len(ws.calls))
+                except Exception:  # noqa: BLE001 — a broken oracle is caught by `bench validate`
+                    _PAR_CACHE[tid] = None
     return _PAR_CACHE[tid]
 
 

--- a/benchkit/agentic/tasks_hard.py
+++ b/benchkit/agentic/tasks_hard.py
@@ -636,9 +636,9 @@ print("OK")
     },
     check=lambda ws: ((False, "business_days.py was modified — it matched the documented behaviour")
                       if ws.files.get("business_days.py") != ws.initial.get("business_days.py")
-                      else ((False, f"changed {ws.changed_lines('tests.py')} lines of tests.py; "
+                      else ((False, f"changed {n} lines of tests.py; "
                                     "only the incorrect expectation needed to change")
-                            if ws.changed_lines("tests.py") > 4 else _visible(ws))),
+                            if (n := ws.changed_lines("tests.py")) > 4 else _visible(ws))),
     oracle=lambda ws: [
         call(ws, "run_python", {"path": "tests.py"}),
         call(ws, "read_file", {"path": "DOCS.md"}),

--- a/tests/test_agentic_loop.py
+++ b/tests/test_agentic_loop.py
@@ -311,6 +311,51 @@ class TestParCalls(unittest.TestCase):
         par = loop.par_calls(bad_task)
         self.assertIsNone(par)
 
+    def test_par_oracle_runs_once_under_concurrency(self):
+        """Concurrent par_calls on a cold cache runs the oracle exactly once."""
+        import concurrent.futures as cf
+        import time
+
+        oracle_runs = []
+
+        def slow_oracle(ws):
+            oracle_runs.append(1)
+            time.sleep(0.05)  # widen the window an unguarded memo would race on
+            ws.write_file("hello.txt", "hello\n")
+            ws.finish("done")
+
+        task = dict(id="par-concurrent", difficulty="easy", prompt="x",
+                    files={}, check=lambda ws: (True, ""),
+                    oracle=slow_oracle)
+        with cf.ThreadPoolExecutor(max_workers=4) as ex:
+            futures = [ex.submit(loop.par_calls, task) for _ in range(4)]
+            pars = [f.result() for f in futures]
+        self.assertEqual(len(oracle_runs), 1)
+        self.assertEqual(pars, [1, 1, 1, 1])
+
+    def test_par_concurrent_distinct_tasks_each_run_once(self):
+        """Every distinct task's oracle runs exactly once under concurrency 4."""
+        import concurrent.futures as cf
+
+        oracle_runs = []
+
+        def make_task(tid):
+            def oracle(ws):
+                oracle_runs.append(tid)
+                ws.write_file("hello.txt", "hello\n")
+                ws.finish("done")
+            return dict(id=tid, difficulty="easy", prompt="x",
+                        files={}, check=lambda ws: (True, ""), oracle=oracle)
+
+        tasks = [make_task(f"par-multi-{i}") for i in range(4)]
+        work = [(t, s) for t in tasks for s in range(2)]
+        with cf.ThreadPoolExecutor(max_workers=4) as ex:
+            futs = [ex.submit(loop.par_calls, t) for t, _ in work]
+            pars = [f.result() for f in futs]
+        self.assertEqual(sorted(oracle_runs),
+                         sorted(t["id"] for t in tasks))
+        self.assertEqual(set(pars), {1})
+
 
 # ---------------------------------------------------------------------------
 # Tests — summarize

--- a/tests/test_agentic_tasks_hard.py
+++ b/tests/test_agentic_tasks_hard.py
@@ -1,0 +1,63 @@
+"""Tests for benchkit/agentic/tasks_hard.py — task predicate behaviour.
+
+Focus: the wrong_test_not_code predicate evaluates `ws.changed_lines("tests.py")`
+at most once per call (F-PERF-005) and still routes to the same verdicts.
+"""
+import sys
+import unittest
+
+sys.path.insert(0, __import__("os").path.dirname(__import__("os").path.dirname(
+    __import__("os").path.abspath(__file__))))
+
+from benchkit.agentic.env import Workspace  # noqa: E402
+from benchkit.agentic.tasks_hard import TASKS  # noqa: E402
+
+
+class CountingWorkspace(Workspace):
+    """A workspace that counts changed_lines evaluations."""
+
+    def __init__(self, files):
+        super().__init__(files)
+        self.changed_line_queries = 0
+
+    def changed_lines(self, path):
+        self.changed_line_queries += 1
+        return super().changed_lines(path)
+
+
+def _wrong_test_task():
+    return next(t for t in TASKS if t["id"] == "wrong_test_not_code")
+
+
+class TestWrongTestNotCodeCheck(unittest.TestCase):
+    """The restraint predicate computes its diff once and keeps its verdicts."""
+
+    def setUp(self):
+        self.task = _wrong_test_task()
+        self.original_tests = self.task["files"]["tests.py"]
+        self.original_code = self.task["files"]["business_days.py"]
+
+    def test_untouched_workspace_queries_changed_lines_once(self):
+        ws = CountingWorkspace(dict(self.task["files"]))
+        solved, _detail = self.task["check"](ws)
+        self.assertEqual(ws.changed_line_queries, 1)
+
+    def test_over_edited_tests_fail_with_single_query(self):
+        ws = CountingWorkspace(dict(self.task["files"]))
+        ws.files["tests.py"] = self.original_tests + "\n" * 10
+        solved, detail = self.task["check"](ws)
+        self.assertEqual(ws.changed_line_queries, 1)
+        self.assertFalse(solved)
+        self.assertIn("lines of tests.py", detail)
+
+    def test_modified_solution_short_circuits_before_diff(self):
+        ws = CountingWorkspace(dict(self.task["files"]))
+        ws.files["business_days.py"] = "# tampered\n"
+        solved, detail = self.task["check"](ws)
+        self.assertEqual(ws.changed_line_queries, 0)
+        self.assertFalse(solved)
+        self.assertIn("business_days.py was modified", detail)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_agentic_tasks_hard.py
+++ b/tests/test_agentic_tasks_hard.py
@@ -35,7 +35,6 @@ class TestWrongTestNotCodeCheck(unittest.TestCase):
     def setUp(self):
         self.task = _wrong_test_task()
         self.original_tests = self.task["files"]["tests.py"]
-        self.original_code = self.task["files"]["business_days.py"]
 
     def test_untouched_workspace_queries_changed_lines_once(self):
         ws = CountingWorkspace(dict(self.task["files"]))


### PR DESCRIPTION
Closes #41

## Summary

Clears the two remaining performance findings (F-PERF-005, F-PERF-006) with
performance-only changes: no scoring behaviour changes, and every recorded
`par_calls` value is byte-identical to before.

## Approach

- **F-PERF-005** — `wrong_test_not_code`'s `check` lambda evaluated
  `ws.changed_lines("tests.py")` twice per predicate evaluation, each an
  O(n²) `difflib.ndiff`. The value is now computed once and bound with a
  walrus operator; Python evaluates the conditional expression's condition
  first, so the message branch sees the bound value. Verdict routing is
  unchanged.
- **F-PERF-006** — `_PAR_CACHE` in `benchkit/agentic/loop.py` was mutated
  lazily from `ThreadPoolExecutor` worker threads with no synchronisation,
  so concurrent samples could each run a task's oracle (wasted work and a
  data race on the memo). `par_calls` now uses double-checked locking:
  lock-free reads after warm-up, and exactly one oracle run per task id on
  a cold cache.

## Decision Record

From Steps 1–2 analysis:

| Option | Description | Outcome |
|---|---|---|
| Minimal | Walrus binding only; leave cache unguarded | Rejected — leaves F-PERF-006 open |
| **Balanced (selected)** | Walrus binding + double-checked lock-guarded memo | Smallest diff that closes both findings; keeps lazy semantics and lock-free warm reads |
| Comprehensive | Precompute par for all tasks before the pool starts + named check function | Rejected — rewrites `run()` flow for no additional guarantee |

## Changes

| File | Change |
|------|--------|
| `benchkit/agentic/tasks_hard.py` | Compute `ws.changed_lines("tests.py")` once per predicate evaluation (walrus bind) |
| `benchkit/agentic/loop.py` | Guard `_PAR_CACHE` with `threading.Lock` via double-checked locking |
| `tests/test_agentic_loop.py` | Oracle-runs-exactly-once tests under concurrency 4 (single task; 4 distinct tasks × 2 samples) |
| `tests/test_agentic_tasks_hard.py` | New: predicate queries the diff at most once per call and keeps its verdicts |

## Test Results

- `python3 -m pytest tests/ -q` → **220 passed**, 54 subtests passed
- `./bench validate` → **28/28** reference solutions pass
- `./bench validate --suite agentic-all` → **16/16** oracles solve their task
- Recorded `par_calls` values diffed clean against a pre-change capture of all 16 agentic tasks

## Acceptance Criteria Verification

| Criterion | Status |
|---|---|
| `changed_lines` is computed once per evaluation of that predicate | ✅ `test_agentic_tasks_hard.py` asserts exactly 1 query when reached, 0 on short-circuit |
| `par_calls` lock-guarded; oracle runs exactly once per task under concurrency 4 | ✅ Two new tests assert one oracle run across 4 threads |
| `./bench validate --suite agentic-all` still 16/16 with unchanged `par_calls` | ✅ Verified |
| `./bench validate && ./bench validate --suite agentic-all` passes at 44/44 | ✅ 28/28 + 16/16 |
