### PR TITLE
refactor(router): bound request buffering and cache backend discovery (#39)

### DIFF
--- a/SERVING.md
+++ b/SERVING.md
@@ -42,6 +42,19 @@ Changing which model hides behind the alias: edit `MODEL_ID` /
 `--served-model-name` in `start-qwen.sh`, then restart the unit. Clients never
 change.
 
+### Router limits
+
+- **Request bodies** are capped at `CLIENT_MAX_SIZE` = 262 144 tokens × 16
+  B/token ≈ 4 MiB, derived from the `--max-model-len 262144` that
+  `start-qwen.sh` pins: a larger body cannot fit the context window anyway and
+  is rejected with `413` instead of being buffered.
+- **Backend discovery** (`/v1/models` fetches) is cached for
+  `ROUTER_DISCOVERY_TTL` seconds (default 60); one listing request costs at
+  most one upstream call per backend.
+- An unknown model name triggers at most one re-discovery per name per
+  `ROUTER_UNKNOWN_MODEL_TTL` seconds (default 60); retries of the same bogus
+  name cost no upstream traffic.
+
 ## Connecting clients
 
 Model is selected by the `model` field in the request body (or `--model` /

--- a/router.py
+++ b/router.py
@@ -15,6 +15,7 @@ import asyncio
 import json
 import logging
 import os
+import time
 
 from aiohttp import ClientSession, ClientTimeout, web
 
@@ -22,13 +23,37 @@ LISTEN_HOST = os.environ.get("ROUTER_HOST") or "127.0.0.1"
 LISTEN_PORT = int(os.environ.get("ROUTER_PORT", "8001"))
 ROUTER_TOKEN = os.environ.get("ROUTER_TOKEN", "")
 
+# Request bodies are capped at MAX_MODEL_LEN_TOKENS * BYTES_PER_TOKEN bytes:
+# start-qwen.sh pins --max-model-len 262144, so no servable request can carry
+# more than that many tokens, and 16 bytes per token is generous even for
+# multi-byte UTF-8 plus JSON \uXXXX escaping and formatting overhead (~4 MiB).
+# Anything larger cannot fit the context window anyway, so aiohttp rejects it
+# with 413 instead of buffering up to the previous 1 GiB per concurrent
+# request (issue #39).
+MAX_MODEL_LEN_TOKENS = int(os.environ.get("ROUTER_MAX_MODEL_LEN", "262144"))
+BYTES_PER_TOKEN = 16
+CLIENT_MAX_SIZE = MAX_MODEL_LEN_TOKENS * BYTES_PER_TOKEN
+
+# Backend /v1/models listings are cached for DISCOVERY_TTL_SECONDS: both the
+# routing map and the merged listing come out of one fetch pass (one upstream
+# call per backend). A request naming an unknown model may trigger at most one
+# extra pass per name per UNKNOWN_MODEL_TTL_SECONDS (negative cache), so a
+# misconfigured client in a retry loop cannot hammer every backend (issue #40).
+DISCOVERY_TTL_SECONDS = float(os.environ.get("ROUTER_DISCOVERY_TTL", "60"))
+UNKNOWN_MODEL_TTL_SECONDS = float(os.environ.get("ROUTER_UNKNOWN_MODEL_TTL", "60"))
+_UNKNOWN_ATTEMPTS_MAX = 4096
+
 
 def _is_loopback(host: str) -> bool:
     """Return True when *host* resolves to a loopback address."""
     return host in ("127.0.0.1", "::1", "localhost")
 
 
-async def _auth_middleware(request: web.Request, handler) -> web.Response:
+@web.middleware
+async def _auth_middleware(
+    request: web.Request,
+    handler,
+) -> web.StreamResponse:
     """Require a Bearer token when the router is bound non-loopback."""
     if _is_loopback(LISTEN_HOST):
         return await handler(request)
@@ -63,29 +88,63 @@ log = logging.getLogger("router")
 
 # discovered at runtime: upstream-reported model id -> backend base
 _discovered: dict[str, str] = {}
+# merged, deduped /v1/models listing served by handle_models
+_models_cache: list[dict] = []
+# time.monotonic() of the last discovery pass (successful or not)
+_discovered_at: float = float("-inf")
+# unknown model name -> time.monotonic() of the last re-discovery it triggered
+_unknown_attempts: dict[str, float] = {}
 _discover_lock = asyncio.Lock()
 
 
-async def discover(session: ClientSession, force: bool = False) -> None:
-    """Ask each backend which model ids it serves."""
-    async with _discover_lock:
-        if _discovered and not force:
-            return
-        found: dict[str, str] = {}
-        for name, base in BACKENDS.items():
-            try:
-                async with session.get(f"{base}/v1/models") as r:
-                    if r.status != 200:
+async def _fetch_backends(session: ClientSession) -> tuple[dict[str, str], list[dict]]:
+    """Fetch /v1/models from every distinct backend exactly once.
+
+    Returns (model id -> backend base, merged deduped model objects).
+    """
+    found: dict[str, str] = {}
+    data: list[dict] = []
+    seen: set[str] = set()
+    for base in dict.fromkeys(BACKENDS.values()):
+        try:
+            async with session.get(f"{base}/v1/models") as r:
+                if r.status != 200:
+                    continue
+                for m in (await r.json()).get("data", []):
+                    mid = m.get("id")
+                    if not mid:
                         continue
-                    body = await r.json()
-                    for m in body.get("data", []):
-                        if m.get("id"):
-                            found[m["id"]] = base
-            except Exception as e:
-                log.warning("discover %s (%s) failed: %s", name, base, e)
-        if found:
-            _discovered.clear()
-            _discovered.update(found)
+                    if mid not in found:
+                        found[mid] = base
+                    if mid not in seen:
+                        seen.add(mid)
+                        data.append(m)
+        except Exception as e:
+            log.warning("discover %s failed: %s", base, e)
+    return found, data
+
+
+async def _discover_locked(session: ClientSession, force: bool = False) -> None:
+    """Run at most one backend fetch pass; caller holds _discover_lock."""
+    global _models_cache, _discovered_at
+    now = time.monotonic()
+    # Freshness is tracked by _discovered_at alone: an empty pass (every
+    # backend down or still loading) also counts as fresh, so a dead backend
+    # is re-polled at most once per TTL instead of on every request.
+    if not force and now - _discovered_at < DISCOVERY_TTL_SECONDS:
+        return
+    found, data = await _fetch_backends(session)
+    if found:
+        _discovered.clear()
+        _discovered.update(found)
+        _models_cache = data
+    _discovered_at = now
+
+
+async def discover(session: ClientSession, force: bool = False) -> None:
+    """Ask each backend which model ids it serves (TTL-cached)."""
+    async with _discover_lock:
+        await _discover_locked(session, force)
 
 
 def resolve(model: str) -> str | None:
@@ -98,23 +157,40 @@ def known_models() -> list[str]:
     return sorted(set(BACKENDS) | set(_discovered))
 
 
+async def resolve_or_refresh(session: ClientSession, model: str) -> str | None:
+    """Resolve *model*, re-discovering at most once per name per TTL.
+
+    An unknown model triggers one discovery pass — and only if the cached
+    listing is stale; a fresh listing that lacks the name is authoritative.
+    Either way the attempt is remembered, so retries of the same unknown
+    model cost no upstream traffic until UNKNOWN_MODEL_TTL_SECONDS elapses.
+    """
+    base = resolve(model)
+    if base is not None:
+        return base
+    async with _discover_lock:
+        now = time.monotonic()
+        last = _unknown_attempts.get(model, float("-inf"))
+        if now - last < UNKNOWN_MODEL_TTL_SECONDS:
+            return None  # negative cache hit: recently tried for this name
+        _unknown_attempts[model] = now
+        if len(_unknown_attempts) > _UNKNOWN_ATTEMPTS_MAX:
+            for stale in [k for k, t in _unknown_attempts.items()
+                          if t < now - UNKNOWN_MODEL_TTL_SECONDS]:
+                del _unknown_attempts[stale]
+        if not (_discovered and now - _discovered_at < DISCOVERY_TTL_SECONDS):
+            # listing is stale or empty — one refresh attempt (a no-op when
+            # another pass just completed under this lock)
+            await _discover_locked(session)
+    return resolve(model)
+
+
 async def handle_models(request: web.Request) -> web.Response:
     session: ClientSession = request.app["session"]
-    await discover(session, force=True)
-    data = []
-    seen = set()
-    for base in dict.fromkeys(BACKENDS.values()):
-        try:
-            async with session.get(f"{base}/v1/models") as r:
-                if r.status != 200:
-                    continue
-                for m in (await r.json()).get("data", []):
-                    if m.get("id") and m["id"] not in seen:
-                        seen.add(m["id"])
-                        data.append(m)
-        except Exception as e:
-            log.warning("models from %s failed: %s", base, e)
-    return web.json_response({"object": "list", "data": data})
+    # One TTL-gated discovery pass fills both the routing map and the merged
+    # listing; within the TTL this serves from cache with no upstream calls.
+    await discover(session)
+    return web.json_response({"object": "list", "data": list(_models_cache)})
 
 
 async def handle_health(request: web.Request) -> web.Response:
@@ -137,7 +213,17 @@ async def handle_health(request: web.Request) -> web.Response:
 
 async def proxy(request: web.Request) -> web.StreamResponse:
     session: ClientSession = request.app["session"]
-    raw = await request.read()
+    try:
+        raw = await request.read()
+    except web.HTTPRequestEntityTooLarge:
+        # aiohttp enforces CLIENT_MAX_SIZE before buffering; nothing beyond
+        # the limit is ever read (issue #39).
+        return web.json_response(
+            {"error": {"message": f"request body too large; limit is "
+                                  f"{CLIENT_MAX_SIZE} bytes",
+                       "type": "invalid_request_error",
+                       "code": "request_too_large"}},
+            status=413)
     try:
         payload = json.loads(raw) if raw else {}
     except json.JSONDecodeError:
@@ -151,10 +237,7 @@ async def proxy(request: web.Request) -> web.StreamResponse:
             {"error": {"message": "missing 'model'", "type": "invalid_request_error"}},
             status=400)
 
-    base = resolve(model)
-    if base is None:
-        await discover(session, force=True)
-        base = resolve(model)
+    base = await resolve_or_refresh(session, model)
     if base is None:
         return web.json_response(
             {"error": {"message": f"unknown model {model!r}; available: "
@@ -202,10 +285,9 @@ async def on_stop(app: web.Application) -> None:
     await app["session"].close()
 
 
-def main() -> None:
-    logging.basicConfig(level=logging.INFO,
-                        format="%(asctime)s %(levelname)s %(name)s: %(message)s")
-    app = web.Application(client_max_size=1024 ** 3, middlewares=[_auth_middleware])
+def create_app() -> web.Application:
+    app = web.Application(client_max_size=CLIENT_MAX_SIZE,
+                          middlewares=[_auth_middleware])
     app.on_startup.append(on_start)
     app.on_cleanup.append(on_stop)
     app.router.add_get("/v1/models", handle_models)
@@ -218,6 +300,13 @@ def main() -> None:
                  "/v1/messages", "/v1/messages/count_tokens",
                  "/v1/responses"):
         app.router.add_post(path, proxy)
+    return app
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO,
+                        format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+    app = create_app()
     mode = "loopback (no auth)" if _is_loopback(LISTEN_HOST) else "non-loopback"
     if ROUTER_TOKEN:
         mode += " + bearer token required"

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -5,14 +5,30 @@ Covers issue #16: Bind the router to loopback by default.
 - Non-loopback bind requires ROUTER_TOKEN bearer auth, returns 401 without it
 - Loopback binds stay open (no auth required)
 - When ROUTER_TOKEN is empty, auth is disabled regardless of bind
+
+Covers issue #39: Bound the router request buffering.
+- CLIENT_MAX_SIZE derives from the pinned 262144-token context (~4 MiB)
+- Bodies over the limit return 413 without being forwarded
+- A max-context-sized prompt still routes end to end
+
+Covers issue #40: Stop the router rediscovering on every call.
+- One GET /v1/models costs exactly one upstream call per backend
+- Repeat requests are served from the TTL cache
+- Unknown-model retries trigger at most one re-discovery per TTL
 """
 import asyncio
+import importlib
+import json
 import os
 import sys
+import time
 import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from aiohttp import web  # noqa: E402
+from aiohttp.test_utils import TestClient, TestServer  # noqa: E402
 
 import router  # noqa: E402
 
@@ -49,7 +65,17 @@ class TestIsLoopback(unittest.TestCase):
 
 
 class TestAuthMiddleware(unittest.TestCase):
-    """Bearer-token auth when non-loopback + ROUTER_TOKEN is set."""
+    """Bearer-token auth when non-loopback + ROUTER_TOKEN is set.
+
+    The middleware is aiohttp's version-1 style (@web.middleware): callable
+    as (request, handler) directly, which is also how the tests invoke it.
+    """
+
+    def test_middleware_is_registered_version_one_style(self):
+        import inspect
+        self.assertTrue(inspect.iscoroutinefunction(router._auth_middleware))
+        self.assertEqual(getattr(router._auth_middleware,
+                                 "__middleware_version__", None), 1)
 
     def _make_request(self, auth_header=""):
         """Create a mock aiohttp web.Request."""
@@ -66,7 +92,6 @@ class TestAuthMiddleware(unittest.TestCase):
     def test_non_loopback_no_token_returns_401(self):
         """When bound non-loopback with a token, no auth → 401."""
         with patch.dict(os.environ, {"ROUTER_HOST": "0.0.0.0", "ROUTER_TOKEN": "secret"}):
-            import importlib
             importlib.reload(router)
 
             request = self._make_request(auth_header="")
@@ -75,9 +100,7 @@ class TestAuthMiddleware(unittest.TestCase):
                 return MagicMock(status=200)
 
             async def run():
-                middleware = router._auth_middleware
-                result = await middleware(request, handler)
-                return result
+                return await router._auth_middleware(request, handler)
 
             result = asyncio.get_event_loop().run_until_complete(run())
             self.assertEqual(result.status, 401)
@@ -85,7 +108,6 @@ class TestAuthMiddleware(unittest.TestCase):
     def test_non_loopback_correct_token_passes(self):
         """When bound non-loopback with correct token, auth passes."""
         with patch.dict(os.environ, {"ROUTER_HOST": "0.0.0.0", "ROUTER_TOKEN": "secret"}):
-            import importlib
             importlib.reload(router)
 
             request = self._make_request(auth_header="secret")
@@ -94,9 +116,7 @@ class TestAuthMiddleware(unittest.TestCase):
                 return MagicMock(status=200)
 
             async def run():
-                middleware = router._auth_middleware
-                result = await middleware(request, handler)
-                return result
+                return await router._auth_middleware(request, handler)
 
             result = asyncio.get_event_loop().run_until_complete(run())
             self.assertEqual(result.status, 200)
@@ -104,7 +124,6 @@ class TestAuthMiddleware(unittest.TestCase):
     def test_non_loopback_wrong_token_returns_401(self):
         """Wrong token → 401."""
         with patch.dict(os.environ, {"ROUTER_HOST": "0.0.0.0", "ROUTER_TOKEN": "secret"}):
-            import importlib
             importlib.reload(router)
 
             request = self._make_request(auth_header="wrong")
@@ -113,9 +132,7 @@ class TestAuthMiddleware(unittest.TestCase):
                 return MagicMock(status=200)
 
             async def run():
-                middleware = router._auth_middleware
-                result = await middleware(request, handler)
-                return result
+                return await router._auth_middleware(request, handler)
 
             result = asyncio.get_event_loop().run_until_complete(run())
             self.assertEqual(result.status, 401)
@@ -123,7 +140,6 @@ class TestAuthMiddleware(unittest.TestCase):
     def test_loopback_no_auth_required(self):
         """Loopback bind: auth is skipped entirely."""
         with patch.dict(os.environ, {"ROUTER_HOST": "127.0.0.1", "ROUTER_TOKEN": "secret"}):
-            import importlib
             importlib.reload(router)
 
             request = self._make_request(auth_header="")
@@ -134,9 +150,7 @@ class TestAuthMiddleware(unittest.TestCase):
                 return handler_resp
 
             async def run():
-                middleware = router._auth_middleware
-                result = await middleware(request, handler)
-                return result
+                return await router._auth_middleware(request, handler)
 
             result = asyncio.get_event_loop().run_until_complete(run())
             # Handler should have been called (no 401)
@@ -145,7 +159,6 @@ class TestAuthMiddleware(unittest.TestCase):
     def test_no_token_configured_opens_all(self):
         """When ROUTER_TOKEN is empty, auth is disabled regardless of bind."""
         with patch.dict(os.environ, {"ROUTER_HOST": "0.0.0.0", "ROUTER_TOKEN": ""}):
-            import importlib
             importlib.reload(router)
 
             request = self._make_request(auth_header="")
@@ -156,9 +169,7 @@ class TestAuthMiddleware(unittest.TestCase):
                 return handler_resp
 
             async def run():
-                middleware = router._auth_middleware
-                result = await middleware(request, handler)
-                return result
+                return await router._auth_middleware(request, handler)
 
             result = asyncio.get_event_loop().run_until_complete(run())
             self.assertEqual(result, handler_resp)
@@ -185,6 +196,368 @@ class TestResolveAndKnownModels(unittest.TestCase):
             importlib.reload(router)
             models = router.known_models()
             self.assertIn("montimage-dgx-spark", models)
+
+
+class TestClientMaxSize(unittest.TestCase):
+    """Issue #39: request bodies are bounded by a documented ceiling."""
+
+    def test_ceiling_derives_from_pinned_context(self):
+        """262144 tokens (start-qwen.sh --max-model-len) x 16 B/token = 4 MiB."""
+        self.assertEqual(router.MAX_MODEL_LEN_TOKENS, 262_144)
+        self.assertEqual(router.CLIENT_MAX_SIZE, 262_144 * 16)
+        self.assertEqual(router.CLIENT_MAX_SIZE, 4 * 1024 * 1024)
+
+    def test_ceiling_is_far_below_the_old_one_gib(self):
+        self.assertLess(router.CLIENT_MAX_SIZE, 1024 ** 3)
+
+    def test_create_app_applies_the_ceiling(self):
+        app = router.create_app()
+        self.assertEqual(app._client_max_size, router.CLIENT_MAX_SIZE)
+
+
+class TestProxyOversizedBody(unittest.IsolatedAsyncioTestCase):
+    """Issue #39: an over-ceiling body returns 413 instead of being buffered."""
+
+    async def test_read_too_large_returns_413_json(self):
+        request = MagicMock()
+        request.read = AsyncMock(
+            side_effect=router.web.HTTPRequestEntityTooLarge(
+                router.CLIENT_MAX_SIZE, router.CLIENT_MAX_SIZE + 1))
+
+        resp = await router.proxy(request)
+        self.assertEqual(resp.status, 413)
+        body = json.loads(resp.body)
+        self.assertEqual(body["error"]["code"], "request_too_large")
+        # nothing past the read was touched
+        request.read.assert_awaited_once()
+
+
+def _reset_discovery_state():
+    router._discovered.clear()
+    router._models_cache = []
+    router._discovered_at = float("-inf")
+    router._unknown_attempts.clear()
+
+
+class _FakeResp:
+    def __init__(self, payload, status=200):
+        self.payload = payload
+        self.status = status
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def json(self):
+        return self.payload
+
+
+class _FakeSession:
+    """Counts /v1/models GETs and answers from a base -> payload map."""
+
+    def __init__(self, payloads_by_url):
+        self.payloads_by_url = payloads_by_url
+        self.calls: list[str] = []
+
+    def get(self, url):
+        self.calls.append(url)
+        return _FakeResp(self.payloads_by_url.get(url, {"data": []}))
+
+
+class TestDiscoveryCache(unittest.IsolatedAsyncioTestCase):
+    """Issue #40 (F-PERF-003): one upstream call per backend, TTL-cached."""
+
+    def setUp(self):
+        with patch.dict(os.environ,
+                        {"ROUTER_HOST": "127.0.0.1", "ROUTER_TOKEN": ""}):
+            importlib.reload(router)
+        _reset_discovery_state()
+
+    def tearDown(self):
+        _reset_discovery_state()
+
+    @staticmethod
+    def _session(payloads=None):
+        return _FakeSession(payloads or {})
+
+    def _two_backend_session(self):
+        payloads = {
+            "http://b1:8801/v1/models":
+                {"data": [{"id": "montimage-dgx-spark"}, {"id": "shared"}]},
+            "http://b2:8802/v1/models":
+                {"data": [{"id": "gemma4-12b"}, {"id": "shared"}]},
+        }
+        session = _FakeSession(payloads)
+        router.BACKENDS.clear()
+        router.BACKENDS.update({"a": "http://b1:8801", "b": "http://b2:8802"})
+        self.addCleanup(lambda: (router.BACKENDS.clear(),
+                                 router.BACKENDS.update(
+                                     {"montimage-dgx-spark": "http://127.0.0.1:8801"})))
+        return session
+
+    async def test_one_pass_per_distinct_backend_dedupes_shared_ids(self):
+        session = self._two_backend_session()
+        await router.discover(session)
+        models_called = [u for u in session.calls if u.endswith("/v1/models")]
+        self.assertEqual(len(models_called), 2)  # one per backend, not one per alias
+        self.assertEqual(sorted(router._discovered),
+                         ["gemma4-12b", "montimage-dgx-spark", "shared"])
+        ids = [m["id"] for m in router._models_cache]
+        self.assertEqual(len(ids), len(set(ids)))  # merged listing is deduped
+
+    async def test_repeat_discovers_within_ttl_cost_nothing(self):
+        session = self._two_backend_session()
+        await router.discover(session)
+        await router.discover(session)
+        await router.discover(session)
+        self.assertEqual(len(session.calls), 2)
+
+    async def test_force_bypasses_the_ttl(self):
+        session = self._two_backend_session()
+        await router.discover(session)
+        await router.discover(session, force=True)
+        self.assertEqual(len(session.calls), 4)
+
+    async def test_concurrent_discovers_share_one_pass(self):
+        session = self._two_backend_session()
+        await asyncio.gather(router.discover(session), router.discover(session))
+        self.assertEqual(len(session.calls), 2)
+
+    async def test_failed_discovery_retried_only_after_ttl(self):
+        router.BACKENDS.clear()
+        router.BACKENDS.update({"a": "http://dead:9/v1"})
+        self.addCleanup(lambda: (router.BACKENDS.clear(),
+                                 router.BACKENDS.update(
+                                     {"montimage-dgx-spark": "http://127.0.0.1:8801"})))
+        session = _FakeSession({})  # every fetch returns no models
+        await router.discover(session)
+        await router.discover(session)
+        self.assertEqual(len(session.calls), 1)  # empty result still counts as fresh
+        router._discovered_at = time.monotonic() - router.DISCOVERY_TTL_SECONDS - 1
+        await router.discover(session)
+        self.assertEqual(len(session.calls), 2)
+
+
+class TestUnknownModelNegativeCache(unittest.IsolatedAsyncioTestCase):
+    """Issue #40 (F-PERF-004): unknown-model retries do not hammer backends."""
+
+    def setUp(self):
+        with patch.dict(os.environ,
+                        {"ROUTER_HOST": "127.0.0.1", "ROUTER_TOKEN": ""}):
+            importlib.reload(router)
+        _reset_discovery_state()
+
+    def tearDown(self):
+        _reset_discovery_state()
+
+    async def test_unknown_model_on_fresh_listing_costs_no_fetch(self):
+        router._discovered.update({"known": "http://b:1"})
+        router._discovered_at = time.monotonic()
+        fetcher = AsyncMock(return_value=({}, []))
+        with patch.object(router, "_fetch_backends", fetcher):
+            base = await router.resolve_or_refresh(MagicMock(), "nope")
+        self.assertIsNone(base)
+        fetcher.assert_not_awaited()
+
+    async def test_retry_loop_triggers_exactly_one_rediscovery(self):
+        fetcher = AsyncMock(return_value=({}, []))  # never finds it
+        with patch.object(router, "_fetch_backends", fetcher):
+            for _ in range(5):
+                base = await router.resolve_or_refresh(MagicMock(), "bogus")
+                self.assertIsNone(base)
+        self.assertEqual(fetcher.await_count, 1)
+
+    async def test_same_name_rediscovered_after_ttl_expires(self):
+        fetcher = AsyncMock(return_value=({}, []))
+        with patch.object(router, "_fetch_backends", fetcher):
+            await router.resolve_or_refresh(MagicMock(), "bogus")
+            router._unknown_attempts["bogus"] -= (
+                router.UNKNOWN_MODEL_TTL_SECONDS + 1)
+            router._discovered_at = float("-inf")
+            await router.resolve_or_refresh(MagicMock(), "bogus")
+        self.assertEqual(fetcher.await_count, 2)
+
+    async def test_distinct_unknown_names_share_one_freshness_window(self):
+        # the first unknown name pays for a refresh; until DISCOVERY_TTL
+        # expires, further distinct names are answered from that fresh
+        # listing without touching any backend — a retry loop cycling
+        # thousands of bogus names costs at most one pass per TTL
+        fetcher = AsyncMock(return_value=({}, []))
+        with patch.object(router, "_fetch_backends", fetcher):
+            for name in ("a", "b", "c"):
+                base = await router.resolve_or_refresh(MagicMock(), name)
+                self.assertIsNone(base)
+        self.assertEqual(fetcher.await_count, 1)
+
+    async def test_attempt_table_is_pruned_when_huge(self):
+        stale_ts = time.monotonic() - router.UNKNOWN_MODEL_TTL_SECONDS - 1
+        for i in range(router._UNKNOWN_ATTEMPTS_MAX + 10):
+            router._unknown_attempts[f"stale{i}"] = stale_ts
+        fetcher = AsyncMock(return_value=({}, []))
+        with patch.object(router, "_fetch_backends", fetcher):
+            await router.resolve_or_refresh(MagicMock(), "fresh-name")
+        self.assertLessEqual(len(router._unknown_attempts),
+                             router._UNKNOWN_ATTEMPTS_MAX)
+
+
+class TestRouterEndToEnd(unittest.IsolatedAsyncioTestCase):
+    """Integration: real aiohttp servers for the router and its backends.
+
+    Issue #39: oversized -> 413, max-context prompt routes end to end.
+    Issue #40: exactly one upstream /v1/models call per backend; the
+    unknown-model retry loop triggers at most one re-discovery per TTL.
+    """
+
+    def _make_backend(self, model_ids):
+        counter = {"models": 0, "chat": 0}
+        last_body = {}
+
+        async def models(request):
+            counter["models"] += 1
+            data = [{"id": mid, "object": "model"} for mid in model_ids]
+            return web.json_response({"object": "list", "data": data})
+
+        async def chat(request):
+            counter["chat"] += 1
+            last_body["raw"] = await request.read()
+            return web.json_response({"received_bytes": len(last_body["raw"])})
+
+        app = web.Application(client_max_size=1024 ** 3)
+        app.router.add_get("/v1/models", models)
+        app.router.add_post("/v1/chat/completions", chat)
+        return app, counter, last_body
+
+    def _install_backends(self, primary, secondary):
+        router.BACKENDS.clear()
+        router.BACKENDS.update({
+            "montimage-dgx-spark": str(primary.make_url("")).rstrip("/"),
+            "gemma4-12b": str(secondary.make_url("")).rstrip("/"),
+        })
+
+        def restore():
+            router.BACKENDS.clear()
+            router.BACKENDS.update(
+                {"montimage-dgx-spark": "http://127.0.0.1:8801"})
+
+        self.addCleanup(restore)
+
+    async def asyncSetUp(self):
+        with patch.dict(os.environ,
+                        {"ROUTER_HOST": "127.0.0.1", "ROUTER_TOKEN": ""}):
+            importlib.reload(router)
+
+        self.primary_app, self.primary_calls, self.primary_last = \
+            self._make_backend(["montimage-dgx-spark"])
+        self.secondary_app, self.secondary_calls, _ = \
+            self._make_backend(["gemma4-12b", "shared-alias"])
+        self.primary = TestServer(self.primary_app)
+        self.secondary = TestServer(self.secondary_app)
+        await self.primary.start_server()
+        await self.secondary.start_server()
+        self.addCleanup(self.primary.close)
+        self.addCleanup(self.secondary.close)
+
+        self._install_backends(self.primary, self.secondary)
+        _reset_discovery_state()
+
+        self.server = TestServer(router.create_app())
+        await self.server.start_server()
+        self.client = TestClient(self.server)
+        self.addCleanup(self.client.close)
+        # ignore the warm-up discovery the router performed during startup:
+        # assertions below must count only test-driven upstream traffic
+        self.primary_calls["models"] = 0
+        self.secondary_calls["models"] = 0
+
+    async def test_models_get_costs_exactly_one_upstream_call_per_backend(self):
+        # expire whatever the router fetched during startup so this GET
+        # demonstrably pays for its own discovery pass
+        router._discovered_at = float("-inf")
+        async with self.client.get("/v1/models") as r:
+            self.assertEqual(r.status, 200)
+            body = await r.json()
+        ids = {m["id"] for m in body["data"]}
+        self.assertIn("montimage-dgx-spark", ids)
+        self.assertIn("gemma4-12b", ids)
+        self.assertIn("shared-alias", ids)
+        self.assertEqual(len(body["data"]), 3)  # deduped across backends
+        self.assertEqual(self.primary_calls["models"], 1)
+        self.assertEqual(self.secondary_calls["models"], 1)
+
+    async def test_second_models_get_within_ttl_touches_no_backend(self):
+        router._discovered_at = float("-inf")
+        async with self.client.get("/v1/models"):
+            pass
+        async with self.client.get("/v1/models"):
+            pass
+        self.assertEqual(self.primary_calls["models"], 1)
+        self.assertEqual(self.secondary_calls["models"], 1)
+
+    async def test_unknown_model_retry_loop_rediscovers_at_most_once(self):
+        _reset_discovery_state()  # ignore the warm-up pass from startup
+        payload = {"model": "does-not-exist", "messages": []}
+        for _ in range(5):
+            async with self.client.post("/v1/chat/completions",
+                                        json=payload) as r:
+                self.assertEqual(r.status, 404)
+        # cold cache: first POST pays one discovery pass; the rest are negative-cache hits
+        self.assertEqual(self.primary_calls["models"], 1)
+        self.assertEqual(self.secondary_calls["models"], 1)
+
+    async def test_unknown_model_rediscovered_after_ttl(self):
+        _reset_discovery_state()
+        payload = {"model": "does-not-exist", "messages": []}
+        async with self.client.post("/v1/chat/completions", json=payload) as r:
+            self.assertEqual(r.status, 404)
+        age = router.UNKNOWN_MODEL_TTL_SECONDS + 1
+        router._unknown_attempts["does-not-exist"] -= age
+        router._discovered_at -= age
+        async with self.client.post("/v1/chat/completions", json=payload) as r:
+            self.assertEqual(r.status, 404)
+        self.assertEqual(self.primary_calls["models"], 2)
+        self.assertEqual(self.secondary_calls["models"], 2)
+
+    async def test_known_alias_still_routes_after_cold_start(self):
+        _reset_discovery_state()
+        payload = {"model": "montimage-dgx-spark",
+                   "messages": [{"role": "user", "content": "hi"}]}
+        async with self.client.post("/v1/chat/completions",
+                                    json=payload) as r:
+            self.assertEqual(r.status, 200)
+            body = await r.json()
+        self.assertEqual(self.primary_calls["chat"], 1)
+        self.assertEqual(body["received_bytes"],
+                         len(json.dumps(payload).encode()))
+
+    async def test_oversized_body_returns_413_without_touching_backend(self):
+        too_big = "A" * (router.CLIENT_MAX_SIZE + 1)
+        payload = {"model": "montimage-dgx-spark",
+                   "messages": [{"role": "user", "content": too_big}]}
+        async with self.client.post("/v1/chat/completions",
+                                    json=payload) as r:
+            self.assertEqual(r.status, 413)
+            body = await r.json()
+        self.assertEqual(body["error"]["code"], "request_too_large")
+        self.assertEqual(self.primary_calls["chat"], 0)
+        self.assertEqual(self.secondary_calls["chat"], 0)
+
+    async def test_max_context_prompt_routes_end_to_end(self):
+        # ~300k tokens of prose (~1.8 MB): above the served context window's
+        # 256k-token mark yet comfortably under the 4 MiB ceiling.
+        content = "token " * 300_000
+        payload = {"model": "montimage-dgx-spark",
+                   "messages": [{"role": "user", "content": content}]}
+        raw = json.dumps(payload).encode()
+        self.assertLess(len(raw), router.CLIENT_MAX_SIZE)
+        async with self.client.post("/v1/chat/completions", data=raw,
+                                    headers={"Content-Type":
+                                             "application/json"}) as r:
+            self.assertEqual(r.status, 200)
+            body = await r.json()
+        self.assertEqual(body["received_bytes"], len(raw))
+        self.assertEqual(self.primary_calls["chat"], 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Resolves #39 and #40 together — both target `router.py`'s dispatch path, and #40 declares a dependency on #39.

- **#39 (F-PERF-002):** the router buffered every request body with `client_max_size=1024**3` (1 GiB per concurrent request). The ceiling is now `CLIENT_MAX_SIZE = MAX_MODEL_LEN_TOKENS × 16 = ~4 MiB`, derived from the `--max-model-len 262144` pinned at `start-qwen.sh:52` — no servable request can exceed that token count, and 16 B/token is generous for multi-byte UTF-8 plus JSON escaping. Oversized bodies return a JSON `413` without being buffered or forwarded; a max-context-sized prompt still routes end to end.
- **#40 (F-PERF-003, F-PERF-004):** `handle_models` fetched `/v1/models` from every backend and then fetched them all again. Discovery now runs **one fetch pass per distinct backend** that fills both the routing map and the merged, deduped listing, cached for `ROUTER_DISCOVERY_TTL` (default 60 s). Unknown model names go through `resolve_or_refresh()` with a per-name negative cache (`ROUTER_UNKNOWN_MODEL_TTL`, default 60 s) — a retry loop cycling bogus names costs at most one upstream pass per TTL instead of one per request.

## Approach

- `_fetch_backends()` — single pass over distinct backend URLs; builds the id→base routing map and the merged listing in the same loop.
- `_discover_locked()` — freshness tracked by `_discovered_at` alone (an empty pass also counts as fresh, so dead backends are polled at most once per TTL); `discover()` wraps it under the existing lock.
- `resolve_or_refresh()` — unknown-model path: negative-cache gate → staleness-gated single refresh → re-resolve. Attempt table pruned above 4096 entries.
- `proxy()` catches aiohttp's `HTTPRequestEntityTooLarge` and returns a structured 413.
- `create_app()` extracted from `main()` so integration tests can boot the real app.
- **Drive-by fix required by the new integration tests:** aiohttp 3.14 sends undecorated middlewares down its deprecated legacy path, where handlers received the *Application* instead of the *Request* — every live proxied request failed. The auth middleware is now `@web.middleware` version-1 style (canonical on 3.9–3.14, no deprecation warning, matches aiohttp's own `Middleware` typing).

## Decision Record

- **Capping over streaming:** true request-body streaming cannot work here because dispatch needs the parsed `model` field from the JSON body; the issue allows "stream or cap", and capping bounds worst-case memory deterministically.
- **16 B/token ceiling:** covers CJK UTF-8 (3 B/char ≈ 3 B/token worst case), `\uXXXX` JSON escaping (6 B/char), and formatting overhead with ~5× headroom; a 300k-token (~1.8 MB) prompt is verified to route end to end.
- **TTLs default to 60 s**, env-tunable via `ROUTER_DISCOVERY_TTL` / `ROUTER_UNKNOWN_MODEL_TTL`; documented in `SERVING.md § Router limits`.
- **Fresh listing is authoritative:** an unknown name against a fresh listing triggers no upstream traffic at all; only a stale/empty listing earns a re-discovery.

## Changes

| File | Change |
|---|---|
| `router.py` | size ceiling + 413 handling; TTL discovery cache + merged listing; negative cache for unknown models; `@web.middleware` conversion; `create_app()` extraction |
| `tests/test_router.py` | 20 new tests (unit + real-server integration) covering both issues |
| `SERVING.md` | "Router limits" section documenting the ceiling and both TTLs |

## Test Results

- `pytest tests/ -q` → **242 passed**, 54 subtests passed (was 222 tests before this branch)
- `./bench validate` → **28/28**
- `./bench validate --suite agentic-all` → **16/16** (= 44/44 combined, per acceptance criteria)
- `ruff check router.py tests/test_router.py` → clean; `mypy router.py` → clean

Key acceptance-criteria tests:

| Criterion | Test |
|---|---|
| One `GET /v1/models` → exactly one upstream call per backend | `TestRouterEndToEnd::test_models_get_costs_exactly_one_upstream_call_per_backend` |
| Repeated unknown-model requests ≤ 1 re-discovery per TTL | `TestRouterEndToEnd::test_unknown_model_retry_loop_rediscovers_at_most_once`, `::test_unknown_model_rediscovered_after_ttl` |
| Over-ceiling request → 413, not buffered | `TestProxyOversizedBody::test_read_too_large_returns_413_json`, `TestRouterEndToEnd::test_oversized_body_returns_413_without_touching_backend` |
| Max-context prompt routes end to end | `TestRouterEndToEnd::test_max_context_prompt_routes_end_to_end` (300k-token, ~1.8 MB body verified byte-exact at the backend) |

## Acceptance Criteria Verification

| Criterion | Status |
|---|---|
| #39: `client_max_size` lowered to documented ceiling justified by the 262 k-token context | ✅ `router.py` constants block + `SERVING.md` |
| #39: request exceeding ceiling returns 413 rather than being buffered | ✅ unit + integration tests |
| #39: 256 k-token prompt still routes successfully | ✅ `test_max_context_prompt_routes_end_to_end` |
| #40: one `GET /v1/models` produces exactly one upstream `/v1/models` call per backend | ✅ counted-upstream-request tests |
| #40: repeated unknown-model requests trigger at most one re-discovery within documented TTL | ✅ negative-cache tests |
| Both: `./bench validate && ./bench validate --suite agentic-all` at 44/44 | ✅ 28/28 + 16/16 |

> **Note:** the 256 k-token-prompt criterion was validated through the router's own test harness (fake backends + real aiohttp servers), not against a live vLLM endpoint — no serving process was restarted for this PR.