### PR TITLE
fix(harness): derive staged config paths per task (#61)

### DIFF
--- a/benchkit/harness/claudecode.py
+++ b/benchkit/harness/claudecode.py
@@ -90,8 +90,6 @@ CONFIG_DIR = "claude-home"
 class ClaudeCodeHarness(Harness):
     name = "claude-code"
 
-    _config_home = None
-
     def __init__(self, cfg=None, *, tools=DEFAULT_TOOLS, effort=None):
         # `provider` exists only so the shared CLI flag is accepted; Claude Code
         # has no provider concept for a custom base URL.
@@ -208,12 +206,21 @@ class ClaudeCodeHarness(Harness):
         CLAUDE_CONFIG_DIR is pointed at a sibling directory so sessions, project
         state and history never land in the workspace that gets scored, and never
         touch the user's real ~/.claude.
+
+        That sibling's path is derived from `container` and never remembered on
+        `self`: one instance serves every task, and the runner drives those
+        tasks on a thread pool, so a stored path would hand one task another
+        task's config home — shared session state between concurrent tasks, or
+        a directory that has already been cleaned up.
         """
         workdir = os.path.join(container, "work")
         os.makedirs(workdir, exist_ok=True)
-        self._config_home = os.path.join(container, CONFIG_DIR)
-        os.makedirs(self._config_home, exist_ok=True)
+        os.makedirs(self._config_home(workdir), exist_ok=True)
         return workdir
+
+    def _config_home(self, workdir):
+        """Where prepare() made this task's config home, from its workdir alone."""
+        return os.path.join(os.path.dirname(workdir), CONFIG_DIR)
 
     # --- execution ------------------------------------------------------
     def _argv(self, prompt):
@@ -248,9 +255,9 @@ class ClaudeCodeHarness(Harness):
             # A throwaway config home keeps run state out of the user's ~/.claude.
             # It cannot be used in existing-auth mode: the login lives in that
             # directory, and redirecting it would leave every task unauthenticated.
-            env["CLAUDE_CONFIG_DIR"] = (
-                getattr(self, "_config_home", None)
-                or os.path.join(os.path.dirname(workdir), CONFIG_DIR))
+            # Found from this task's workdir, never from shared state — see
+            # prepare().
+            env["CLAUDE_CONFIG_DIR"] = self._config_home(workdir)
         env["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] = "1"
         env["CLAUDE_CODE_ATTRIBUTION_HEADER"] = "0"
         env["DISABLE_AUTOUPDATER"] = "1"

--- a/benchkit/harness/opencode.py
+++ b/benchkit/harness/opencode.py
@@ -46,8 +46,6 @@ DEFAULT_ENDPOINT_PROVIDER = "benchkit"
 class OpenCodeHarness(Harness):
     name = "opencode"
 
-    _config_path = None
-
     def __init__(self, cfg=None, *, variant=None):
         c = cfg or HarnessConfig()
         self.base_url = c.base_url or None
@@ -162,14 +160,23 @@ class OpenCodeHarness(Harness):
         and the failure surfaced as `ProviderModelNotFoundError` a second into
         every task. An explicit path is deterministic; `--dir` then puts the
         project root back on the workspace.
+
+        Its path is derived from `container` and never remembered on `self`:
+        one instance serves every task, and the runner drives those tasks on a
+        thread pool, so a stored path would let one task's subprocess be handed
+        another task's config after that task had been cleaned up — opencode
+        then falls back to the user's own provider with no error at all.
         """
         workdir = os.path.join(container, "work")
         os.makedirs(workdir, exist_ok=True)
         if self.uses_endpoint:
-            self._config_path = os.path.join(container, CONFIG_NAME)
-            with open(self._config_path, "w") as f:
+            with open(self._staged_config(workdir), "w") as f:
                 json.dump(self._config(), f, indent=2)
         return workdir
+
+    def _staged_config(self, workdir):
+        """Where prepare() put this task's config, from its workdir alone."""
+        return os.path.join(os.path.dirname(workdir), CONFIG_NAME)
 
     def _config(self, thinking=None):
         options = {"baseURL": self.base_url}
@@ -210,8 +217,18 @@ class OpenCodeHarness(Harness):
     def run(self, workdir, prompt, timeout=900, thinking=False):
         env = dict(os.environ)
         if self.uses_endpoint:
-            env["OPENCODE_CONFIG"] = getattr(self, "_config_path", None) or \
-                os.path.join(os.path.dirname(workdir), CONFIG_NAME)
+            # Found from this task's workdir, never from shared state — see
+            # prepare().
+            cfg_path = self._staged_config(workdir)
+            if not os.path.isfile(cfg_path):
+                # A missing staged config must not look like a working run:
+                # opencode would silently fall back to the user's own config
+                # and the benchmark would measure the wrong provider.
+                return HarnessResult(
+                    stop_reason="error",
+                    error=f"no staged config at {cfg_path}; refusing to let "
+                          f"opencode fall back to your own config")
+            env["OPENCODE_CONFIG"] = cfg_path
         env["OPENCODE_DISABLE_AUTOUPDATE"] = "1"
         try:
             p = subprocess.run(self._argv(prompt, workdir), cwd=workdir, env=env,

--- a/tests/test_harness_staged_config_race.py
+++ b/tests/test_harness_staged_config_race.py
@@ -148,7 +148,7 @@ class TestClaudeCodeStaging(StagedPathCase):
         return get("claude-code", HarnessConfig(model="sonnet",
                                                 base_url=ENDPOINT))
 
-    def test_prepare_makes_the_config_home_but_remember_nothing(self):
+    def test_prepare_makes_the_config_home_but_remembers_nothing(self):
         h = self.harness()
         before = dict(vars(h))
         workdir = h.prepare(self.containers(1)[0])

--- a/tests/test_harness_staged_config_race.py
+++ b/tests/test_harness_staged_config_race.py
@@ -1,0 +1,196 @@
+"""Tests for per-task staged config paths in the opencode/claude-code adapters.
+
+The runner drives every task through ONE harness instance on a thread pool
+(`benchkit/harness/runner.py`), so an adapter must never park a per-task path
+on itself: the last task to call prepare() would win, and every other task's
+subprocess would be pointed at a directory that has since been rmtree'd. For
+opencode that failure was silent — opencode falls back to the user's own
+config and the benchmark measures the wrong provider with no error.
+
+The promise tested here: N parallel tasks sharing one adapter instance get N
+distinct staged paths, checked against what `run()` actually hands the
+subprocess — plus a missing staged config failing loudly instead of silently.
+"""
+import os
+import shutil
+import sys
+import tempfile
+import threading
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from benchkit.harness import HarnessConfig, get  # noqa: E402
+from benchkit.harness.claudecode import CONFIG_DIR as CLAUDE_HOME  # noqa: E402
+from benchkit.harness.opencode import CONFIG_NAME  # noqa: E402
+
+ENDPOINT = "http://localhost:8001/v1"
+
+TASKS = 8
+
+
+class _FakeProcess:
+    stdout = ""
+    stderr = ""
+    returncode = 0
+
+
+class StagedPathCase(unittest.TestCase):
+    """A fresh run container set, one shared adapter, captured subprocess env."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+
+    def containers(self, n=TASKS):
+        out = []
+        for i in range(n):
+            c = os.path.join(self.tmp.name, f"task-{i}")
+            os.makedirs(c)
+            out.append(c)
+        return out
+
+    def staged_path(self, workdir, name):
+        return os.path.join(os.path.dirname(workdir), name)
+
+
+class TestOpenCodeStaging(StagedPathCase):
+    def harness(self):
+        return get("opencode", HarnessConfig(model="m", base_url=ENDPOINT))
+
+    def test_run_hands_the_subprocess_this_tasks_own_config(self):
+        h = self.harness()
+        first, second = self.containers(2)
+        w1 = h.prepare(first)
+        w2 = h.prepare(second)
+        seen = {}
+        with mock.patch("subprocess.run", return_value=_FakeProcess()) as run:
+            h.run(w1, "p")
+            h.run(w2, "p")
+            seen[w1] = run.call_args_list[0].kwargs["env"]["OPENCODE_CONFIG"]
+            seen[w2] = run.call_args_list[1].kwargs["env"]["OPENCODE_CONFIG"]
+        self.assertEqual(seen[w1], self.staged_path(w1, CONFIG_NAME))
+        self.assertEqual(seen[w2], self.staged_path(w2, CONFIG_NAME))
+        self.assertNotEqual(seen[w1], seen[w2])
+
+    def test_parallel_tasks_on_one_shared_instance_get_distinct_paths(self):
+        """The runner's actual shape: one instance, a thread pool, many tasks.
+
+        A barrier holds every fake subprocess open until all N tasks are inside
+        run(), maximising the interleaving under the old shared-field code,
+        where every task would have been handed whichever path prepare() wrote
+        last.
+        """
+        h = self.harness()
+        workdirs = [h.prepare(c) for c in self.containers()]
+        barrier = threading.Barrier(TASKS)
+        lock = threading.Lock()
+        handed = {}
+
+        def fake_run(argv, **kw):
+            barrier.wait(timeout=30)
+            with lock:
+                handed[kw["cwd"]] = kw["env"].get("OPENCODE_CONFIG")
+            return _FakeProcess()
+
+        before = dict(vars(h))
+        with mock.patch("subprocess.run", side_effect=fake_run):
+            with ThreadPoolExecutor(max_workers=TASKS) as ex:
+                list(ex.map(lambda w: h.run(w, "p"), workdirs))
+
+        self.assertEqual(len(handed), TASKS, "each task ran exactly once")
+        for wd in workdirs:
+            self.assertEqual(handed[wd], self.staged_path(wd, CONFIG_NAME),
+                             f"task {wd} was handed another task's config")
+        self.assertEqual(len(set(handed.values())), TASKS,
+                         "concurrent tasks must get distinct staged paths")
+        self.assertEqual(vars(h), before,
+                         "no adapter field may be written after __init__")
+
+    def test_a_missing_staged_config_fails_loudly(self):
+        """No silent fallback: opencode must not end up benchmarking our config."""
+        h = self.harness()
+        container, = self.containers(1)
+        workdir = h.prepare(container)
+        shutil.rmtree(container)
+
+        res = h.run(workdir, "p")
+        self.assertEqual(res.stop_reason, "error")
+        self.assertIn(self.staged_path(workdir, CONFIG_NAME), res.error)
+        self.assertIn("staged config", res.error)
+
+    def test_a_missing_staged_config_never_runs_opencode(self):
+        h = self.harness()
+        container, = self.containers(1)
+        workdir = h.prepare(container)
+        shutil.rmtree(container)
+        with mock.patch("subprocess.run",
+                        side_effect=AssertionError("must not be invoked")):
+            h.run(workdir, "p")
+
+    def test_without_an_endpoint_nothing_is_redirected(self):
+        h = get("opencode", HarnessConfig(provider="ollama", model="m"))
+        container, = self.containers(1)
+        workdir = h.prepare(container)
+        self.assertFalse(os.path.exists(self.staged_path(workdir, CONFIG_NAME)),
+                         "endpoint-less runs must stage no config")
+        seen = {}
+        with mock.patch("subprocess.run", return_value=_FakeProcess()) as run:
+            h.run(workdir, "p")
+            seen["env"] = run.call_args.kwargs["env"]
+        self.assertNotIn("OPENCODE_CONFIG", seen["env"])
+
+
+class TestClaudeCodeStaging(StagedPathCase):
+    def harness(self):
+        return get("claude-code", HarnessConfig(model="sonnet",
+                                                base_url=ENDPOINT))
+
+    def test_prepare_makes_the_config_home_but_remember_nothing(self):
+        h = self.harness()
+        before = dict(vars(h))
+        workdir = h.prepare(self.containers(1)[0])
+        self.assertTrue(os.path.isdir(
+            self.staged_path(workdir, CLAUDE_HOME)))
+        self.assertEqual(vars(h), before,
+                         "no adapter field may be written after __init__")
+
+    def test_parallel_tasks_on_one_shared_instance_get_distinct_paths(self):
+        h = self.harness()
+        workdirs = [h.prepare(c) for c in self.containers()]
+        barrier = threading.Barrier(TASKS)
+        lock = threading.Lock()
+        handed = {}
+
+        def fake_run(argv, **kw):
+            barrier.wait(timeout=30)
+            with lock:
+                handed[kw["cwd"]] = kw["env"].get("CLAUDE_CONFIG_DIR")
+            return _FakeProcess()
+
+        with mock.patch("subprocess.run", side_effect=fake_run):
+            with ThreadPoolExecutor(max_workers=TASKS) as ex:
+                list(ex.map(lambda w: h.run(w, "p"), workdirs))
+
+        self.assertEqual(len(handed), TASKS, "each task ran exactly once")
+        for wd in workdirs:
+            self.assertEqual(handed[wd], self.staged_path(wd, CLAUDE_HOME),
+                             f"task {wd} was handed another task's home")
+        self.assertEqual(len(set(handed.values())), TASKS,
+                         "concurrent tasks must get distinct config homes")
+
+    def test_without_an_endpoint_nothing_is_redirected(self):
+        h = get("claude-code", HarnessConfig(model="sonnet"))
+        container, = self.containers(1)
+        workdir = h.prepare(container)
+        seen = {}
+        with mock.patch("subprocess.run", return_value=_FakeProcess()) as run:
+            h.run(workdir, "p")
+            seen["env"] = run.call_args.kwargs["env"]
+        self.assertNotIn("CLAUDE_CONFIG_DIR", seen["env"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #61

> **Known overlap:** open PR #72 (`refactor/38-stream-popen-harness-logs`) also touches `benchkit/harness/opencode.py` and `claudecode.py`. This PR is branched from main and deliberately keeps its edits to those files method-level and outside the regions #72 rewrites: it modifies only `prepare()` and the env-construction block at the top of `run()`, while #72 rewrites only the `try/subprocess.run` execution block below that. Merge order should be conflict-free or near-zero; if #72 lands first, this branch rebases trivially.

## Summary

The opencode and claude-code harness adapters stored their staged-config path on the shared adapter instance while the runner drives every task through one instance on a thread pool — so concurrent tasks overwrote each other's path. For opencode the failure was silent result corruption: a stale path pointing into an already-`rmtree`'d container made `OPENCODE_CONFIG` reference a deleted file, opencode fell back to the user's own provider, and the benchmark measured the wrong model with no error. Both adapters now apply the pattern pi adopted in #56/#60: derive the staged location per task from its workdir and write no instance field after `__init__`. A missing staged config now fails the task loudly instead of falling back.

## Approach

- Each adapter gains a derivation helper — `_staged_config(workdir)` (opencode) / `_config_home(workdir)` (claude-code) — mirroring pi's `_staged_dir(workdir)`: the container layout (`container/work` plus staged siblings) makes `os.path.dirname(workdir)` a deterministic, thread-safe key.
- `prepare()` uses the helper with local state only; the class-level `_config_path`/`_config_home = None` placeholders are removed.
- opencode `run()` checks `os.path.isfile()` on the derived path in endpoint mode before spawning; if absent it returns `stop_reason="error"` naming the missing path rather than letting opencode silently fall back to the user's config. claude-code has no such fallback (endpoint mode injects credentials via env, never reads the user's home), so its defensive per-task `makedirs` stays.

## Decision Record

| Field | Value |
|---|---|
| Selected option | Balanced: per-task derivation helpers + loud-failure guard on opencode |
| Alternatives rejected | Minimal (derive inline in run(), duplicated logic); comprehensive (thread-local or per-task context through base Harness.run() — over-engineered, larger diff worsens overlap with PR #72) |
| Reproduction | Red checkpoint confirmed pre-fix: after two prepares on one instance, task 1's `run()` handed task 2's `OPENCODE_CONFIG`; 5 of 8 new tests fail against the pre-fix adapters |
| Complexity | medium (full profile) |

## Changes

| File | Change |
|------|--------|
| `benchkit/harness/opencode.py` | drop shared `_config_path` field; derive staged config per workdir (`_staged_config`); loud error when the staged config is missing in endpoint mode |
| `benchkit/harness/claudecode.py` | drop shared `_config_home` field; derive config home per workdir (`_config_home`) |
| `tests/test_harness_staged_config_race.py` | new: barrier-synchronised N-task concurrency tests asserting what `run()` hands `subprocess.run`, no-field-after-init assertions, loud-failure tests, endpoint-less regression guards |

## Test Results

- Full suite: `python3 -m unittest discover -s tests -t .` → **250 tests, OK** (242 prior + 8 new)
- Red-check: reverting the two adapters to main → 5/8 new tests fail (the concurrency, loud-failure, and field-mutation assertions), confirming the tests measure the fix
- New tests are binary-independent (`subprocess.run` mocked), so they hold in CI without opencode/claude installed
- `ruff check` clean on all touched paths; repo pre-commit hooks (ruff, mypy, whitespace) pass on every commit

## Acceptance Criteria Verification

| Criterion | Status |
|---|---|
| `opencode.py` derives its staged config path per task from the workdir; no adapter field written after `__init__` | ✅ `_staged_config(workdir)`; asserted by `vars(h)` snapshot across concurrent runs |
| `claudecode.py` does the same for its config home | ✅ `_config_home(workdir)`; same assertion shape |
| Concurrency test proves N parallel tasks on one shared instance get N distinct staged paths, asserted against what `run()` hands the subprocess | ✅ 8 threads, one barrier inside the fake `subprocess.run`, per-cwd env captured and checked for identity and distinctness (both adapters) |
| No silent fallback to the user's own config — a missing staged config fails loudly | ✅ opencode returns `stop_reason="error"` naming the path and never invokes the binary; covered by two dedicated tests |
