### PR TITLE
fix(serving): repair truncated docker run in vLLM launchers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,13 @@ jobs:
       - name: Run ruff check
         run: uv run ruff check .
 
+      # The launchers are the deployment artifact: `./bench apply` copies one
+      # into place and systemd execs it. SC2215/SC1143 catch the truncated
+      # `docker run` that took the endpoint down on 2026-08-24 (see
+      # tests/test_launcher_scripts.py). shellcheck ships on ubuntu-latest.
+      - name: Lint shell launchers (shellcheck)
+        run: shellcheck --severity=warning $(git ls-files '*.sh')
+
       - name: Run mypy
         run: uv run mypy benchkit router.py --ignore-missing-imports
 

--- a/benchkit/agentic/loop.py
+++ b/benchkit/agentic/loop.py
@@ -12,7 +12,7 @@ import time
 
 from ..runner import _summarize_common
 from .env import Workspace, _no_tool_calls, call
-from .tools import TOOLS, SYSTEM
+from .tools import SYSTEM, TOOLS
 
 MAX_TURNS = 25
 

--- a/benchkit/cli.py
+++ b/benchkit/cli.py
@@ -8,9 +8,9 @@ import sys
 HERE = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, HERE)
 
-from benchkit import runner, report  # noqa: E402
-from benchkit.references import REFERENCES  # noqa: E402
-from benchkit.suites import SUITES, DESCRIPTIONS, get, kind  # noqa: E402
+from benchkit import report, runner
+from benchkit.references import REFERENCES
+from benchkit.suites import DESCRIPTIONS, SUITES, get, kind
 
 RESULTS = os.path.join(HERE, "results")
 
@@ -294,7 +294,8 @@ def cmd_sweep(args):
     distinct serving config, behind the shared-endpoint approval gate, and with
     the launcher that was active when the sweep began put back on the way out.
     """
-    from benchkit import serving, sweep as S
+    from benchkit import serving
+    from benchkit import sweep as S
 
     setups = S.parse_setups(args.setups, known_harnesses=_harness_names(),
                             default_model=args.model)

--- a/benchkit/harness/__init__.py
+++ b/benchkit/harness/__init__.py
@@ -2,14 +2,25 @@
 
 See benchkit/harness/base.py for why this exists and ROADMAP.md for what is next.
 """
-__all__ = ["Harness", "HarnessConfig", "HarnessResult", "run_task", "PiHarness",
-           "OpenCodeHarness", "ClaudeCodeHarness", "HARNESSES", "get"]
+__all__ = [
+    "HARNESSES",
+    "ClaudeCodeHarness",
+    "Harness",
+    "HarnessConfig",
+    "HarnessResult",
+    "OpenCodeHarness",
+    "PiHarness",
+    "get",
+    "run_task",
+]
 
-from .base import (Harness as Harness, HarnessConfig as HarnessConfig,
-                   HarnessResult as HarnessResult, run_task as run_task)
-from .pi import PiHarness
-from .opencode import OpenCodeHarness
+from .base import Harness as Harness
+from .base import HarnessConfig as HarnessConfig
+from .base import HarnessResult as HarnessResult
+from .base import run_task as run_task
 from .claudecode import ClaudeCodeHarness
+from .opencode import OpenCodeHarness
+from .pi import PiHarness
 
 HARNESSES = {"pi": PiHarness, "opencode": OpenCodeHarness,
               "claude-code": ClaudeCodeHarness}

--- a/benchkit/runner.py
+++ b/benchkit/runner.py
@@ -11,7 +11,7 @@ import subprocess
 import sys
 import tempfile
 import time
-from dataclasses import dataclass, field, asdict
+from dataclasses import asdict, dataclass, field
 
 SYSTEM = (
     "You are an expert Python programmer. Answer with a single self-contained "
@@ -19,7 +19,7 @@ SYSTEM = (
     "it needs. No explanation, no tests, no example usage."
 )
 
-CODE_RE = re.compile(r"```(?:python|py)?\s*\n(.*?)```", re.S)
+CODE_RE = re.compile(r"```(?:python|py)?\s*\n(.*?)```", re.DOTALL)
 
 
 @dataclass
@@ -107,7 +107,7 @@ def _run_isolated(prog, timeout):
     try:
         proc = subprocess.run(
             ["unshare", "--net", "--mount", sys.executable, "-c",
-             f"exec {sys.executable} -c {repr(prog)}"],
+             f"exec {sys.executable} -c {prog!r}"],
             capture_output=True, text=True, timeout=timeout,
         )
         ok = proc.returncode == 0 and "PASS" in proc.stdout

--- a/benchkit/serving.py
+++ b/benchkit/serving.py
@@ -17,8 +17,8 @@ CONFIGS = os.path.join(HERE, "configs")
 LAUNCHER = os.path.join(HERE, "start-qwen.sh")
 UNIT = "vllm-qwen"
 HEALTH_URL = "http://127.0.0.1:8801/v1/models"
-MODEL_RE = re.compile(r'^MODEL_ID="([^"]+)"', re.M)
-UNIT_RE = re.compile(r'^NAME="([^"$]+)"', re.M)
+MODEL_RE = re.compile(r'^MODEL_ID="([^"]+)"', re.MULTILINE)
+UNIT_RE = re.compile(r'^NAME="([^"$]+)"', re.MULTILINE)
 
 
 def _atomic_write(path: str, content: str) -> None:

--- a/benchkit/suites/__init__.py
+++ b/benchkit/suites/__init__.py
@@ -4,10 +4,10 @@
 raise on failure. Every task has a reference solution in benchkit.references,
 so `bench validate` can prove the tests are passable before blaming a model.
 """
-from .core16 import TASKS as CORE16
-from .hard12 import TASKS as HARD12
 from ..agentic.tasks import TASKS as AGENTIC
 from ..agentic.tasks_hard import TASKS as AGENTIC_HARD
+from .core16 import TASKS as CORE16
+from .hard12 import TASKS as HARD12
 
 SUITES = {
     "core16": CORE16,

--- a/benchkit/sweep.py
+++ b/benchkit/sweep.py
@@ -292,7 +292,7 @@ def _restore(snapshot, serving, restart, log, swallow):
         if restore_launcher(snapshot, serving) and restart:
             log("restarting the endpoint on the original serving config...")
             serving.restart()
-    except BaseException as exc:  # noqa: BLE001 — see docstring
+    except BaseException as exc:
         if not swallow:
             raise
         log(f"WARNING: could not restore the original serving config: {exc!r}")

--- a/configs/ornith-1.5-35b-a3b-nvfp4.sh
+++ b/configs/ornith-1.5-35b-a3b-nvfp4.sh
@@ -25,14 +25,27 @@ HF_HOME="${HF_HOME_DIR:-/home/montimage/llm-serving/hf-cache}"
 mkdir -p "${HF_HOME}"
 docker rm -f "${NAME}" >/dev/null 2>&1 || true
 
+# Why some flags below are required. Keep these notes here: an inline `#`
+# comment on a \-continued line swallows the backslash and truncates the
+# command (that is how the IMAGE argument went missing and the unit crash-looped).
+#   --network host       required: vLLM needs host networking for GPU direct
+#   --cap-add=IPC_LOCK   required: CUDA IPC lock for multi-GPU communication
+#   --ipc host           required: vLLM uses shared memory for tensor parallelism
+#   --trust-remote-code  required: custom MoE backend model architecture
+#   --limit-mm-per-prompt '{"image":0}'
+#       multimodal disabled (#24, F-SEC-002): image:0 rejects media at the
+#       request boundary, so no URL is ever fetched. `--allowed-media-domains ""`
+#       cannot do this -- vLLM parses the empty string as [None] and refuses to
+#       start. To re-enable vision, set image:N and add --allowed-media-domains
+#       with an explicit host allowlist (the default allows every domain).
 exec docker run --rm \
   --name "${NAME}" \
   --user 1000:1000 \
-  --network host   # required: vLLM needs host networking for GPU direct \
+  --network host \
   --shm-size=32g \
   --ulimit memlock=-1:-1 \
-  --cap-add=IPC_LOCK   # required: CUDA IPC lock for multi-GPU communication \
-  --ipc host   # required: vLLM uses shared memory for tensor parallelism \
+  --cap-add=IPC_LOCK \
+  --ipc host \
   --gpus all \
   --entrypoint /usr/local/bin/vllm \
   -e VLLM_TARGET_DEVICE=cuda \
@@ -44,7 +57,7 @@ exec docker run --rm \
     --served-model-name montimage-dgx-spark "${MODEL_ID}" \
     --host 127.0.0.1 --port "${PORT}" \
     --tensor-parallel-size 1 \
-    --trust-remote-code   # required: custom MoE backend model architecture \
+    --trust-remote-code \
     --moe-backend auto \
     --gpu-memory-utilization "${UTIL}" \
     --linear-backend flashinfer_b12x \
@@ -61,6 +74,5 @@ exec docker run --rm \
     --default-chat-template-kwargs '{"enable_thinking":true,"preserve_thinking":true}' \
     --tool-call-parser qwen3_coder \
     --enable-auto-tool-choice \
-    --limit-mm-per-prompt '{"image":4}' \
-    --allowed-media-domains "" \
+    --limit-mm-per-prompt '{"image":0}' \
     --override-generation-config '{"temperature":0.6,"top_p":0.95,"top_k":20,"min_p":0.0}'

--- a/configs/qwen3.6-35b-a3b-nvfp4.sh
+++ b/configs/qwen3.6-35b-a3b-nvfp4.sh
@@ -25,14 +25,27 @@ HF_HOME="${HF_HOME_DIR:-/home/montimage/llm-serving/hf-cache}"
 mkdir -p "${HF_HOME}"
 docker rm -f "${NAME}" >/dev/null 2>&1 || true
 
+# Why some flags below are required. Keep these notes here: an inline `#`
+# comment on a \-continued line swallows the backslash and truncates the
+# command (that is how the IMAGE argument went missing and the unit crash-looped).
+#   --network host       required: vLLM needs host networking for GPU direct
+#   --cap-add=IPC_LOCK   required: CUDA IPC lock for multi-GPU communication
+#   --ipc host           required: vLLM uses shared memory for tensor parallelism
+#   --trust-remote-code  required: custom MoE backend model architecture
+#   --limit-mm-per-prompt '{"image":0}'
+#       multimodal disabled (#24, F-SEC-002): image:0 rejects media at the
+#       request boundary, so no URL is ever fetched. `--allowed-media-domains ""`
+#       cannot do this -- vLLM parses the empty string as [None] and refuses to
+#       start. To re-enable vision, set image:N and add --allowed-media-domains
+#       with an explicit host allowlist (the default allows every domain).
 exec docker run --rm \
   --name "${NAME}" \
   --user 1000:1000 \
-  --network host   # required: vLLM needs host networking for GPU direct \
+  --network host \
   --shm-size=32g \
   --ulimit memlock=-1:-1 \
-  --cap-add=IPC_LOCK   # required: CUDA IPC lock for multi-GPU communication \
-  --ipc host   # required: vLLM uses shared memory for tensor parallelism \
+  --cap-add=IPC_LOCK \
+  --ipc host \
   --gpus all \
   --entrypoint /usr/local/bin/vllm \
   -e VLLM_TARGET_DEVICE=cuda \
@@ -44,7 +57,7 @@ exec docker run --rm \
     --served-model-name montimage-dgx-spark "${MODEL_ID}" \
     --host 127.0.0.1 --port "${PORT}" \
     --tensor-parallel-size 1 \
-    --trust-remote-code   # required: custom MoE backend model architecture \
+    --trust-remote-code \
     --moe-backend auto \
     --gpu-memory-utilization "${UTIL}" \
     --linear-backend flashinfer_b12x \
@@ -61,6 +74,5 @@ exec docker run --rm \
     --default-chat-template-kwargs '{"enable_thinking":true,"preserve_thinking":true}' \
     --tool-call-parser qwen3_coder \
     --enable-auto-tool-choice \
-    --limit-mm-per-prompt '{"image":4}' \
-    --allowed-media-domains "" \
+    --limit-mm-per-prompt '{"image":0}' \
     --override-generation-config '{"temperature":0.6,"top_p":0.95,"top_k":20,"min_p":0.0}'

--- a/configs/qwen3.8-27b-nvfp4-dspark.sh
+++ b/configs/qwen3.8-27b-nvfp4-dspark.sh
@@ -53,14 +53,26 @@ docker rm -f "${NAME}" >/dev/null 2>&1 || true
 # path), so it sits directly in the decode path.
 # VLLM_USE_FLASHINFER_MOE_FP4=0 keeps the MoE path off CUTLASS FP4, reported to
 # emit silent garbage on this architecture. Unused by this dense model.
+# Why some flags below are required. Keep these notes here: an inline `#`
+# comment on a \-continued line swallows the backslash and truncates the
+# command (that is how the IMAGE argument went missing and the unit crash-looped).
+#   --network host       required: vLLM needs host networking for GPU direct
+#   --cap-add=IPC_LOCK   required: CUDA IPC lock for multi-GPU communication
+#   --ipc host           required: vLLM uses shared memory for tensor parallelism
+#   --limit-mm-per-prompt '{"image":0}'
+#       multimodal disabled (#24, F-SEC-002): image:0 rejects media at the
+#       request boundary, so no URL is ever fetched. `--allowed-media-domains ""`
+#       cannot do this -- vLLM parses the empty string as [None] and refuses to
+#       start. To re-enable vision, set image:N and add --allowed-media-domains
+#       with an explicit host allowlist (the default allows every domain).
 exec docker run --rm \
   --name "${NAME}" \
   --user 1000:1000 \
-  --network host   # required: vLLM needs host networking for GPU direct \
+  --network host \
   --shm-size=32g \
   --ulimit memlock=-1:-1 \
-  --cap-add=IPC_LOCK   # required: CUDA IPC lock for multi-GPU communication \
-  --ipc host   # required: vLLM uses shared memory for tensor parallelism \
+  --cap-add=IPC_LOCK \
+  --ipc host \
   --gpus all \
   --entrypoint /usr/local/bin/vllm \
   -e VLLM_MARLIN_USE_ATOMIC_ADD=1 \
@@ -85,6 +97,5 @@ exec docker run --rm \
     --default-chat-template-kwargs '{"enable_thinking":false,"preserve_thinking":true}' \
     --tool-call-parser qwen3_xml \
     --enable-auto-tool-choice \
-    --limit-mm-per-prompt '{"image":4}' \
-    --allowed-media-domains "" \
+    --limit-mm-per-prompt '{"image":0}' \
     --override-generation-config '{"temperature":0.6,"top_p":0.95,"top_k":20,"min_p":0.0}'

--- a/start-qwen.sh
+++ b/start-qwen.sh
@@ -25,14 +25,27 @@ HF_HOME="${HF_HOME_DIR:-/home/montimage/llm-serving/hf-cache}"
 mkdir -p "${HF_HOME}"
 docker rm -f "${NAME}" >/dev/null 2>&1 || true
 
+# Why some flags below are required. Keep these notes here: an inline `#`
+# comment on a \-continued line swallows the backslash and truncates the
+# command (that is how the IMAGE argument went missing and the unit crash-looped).
+#   --network host       vLLM needs host networking for GPU direct
+#   --cap-add=IPC_LOCK   CUDA IPC lock for multi-GPU communication
+#   --ipc host           vLLM uses shared memory for tensor parallelism
+#   --trust-remote-code  custom MoE backend model architecture
+#   --limit-mm-per-prompt '{"image":0}'
+#       multimodal disabled (#24, F-SEC-002): image:0 rejects media at the
+#       request boundary, so no URL is ever fetched. `--allowed-media-domains ""`
+#       cannot do this -- vLLM parses the empty string as [None] and refuses to
+#       start. To re-enable vision, set image:N and add --allowed-media-domains
+#       with an explicit host allowlist (the default allows every domain).
 exec docker run --rm \
   --name "${NAME}" \
   --user 1000:1000 \
-  --network host   # required: vLLM needs host networking for GPU direct \
+  --network host \
   --shm-size=32g \
   --ulimit memlock=-1:-1 \
-  --cap-add=IPC_LOCK   # required: CUDA IPC lock for multi-GPU communication \
-  --ipc host   # required: vLLM uses shared memory for tensor parallelism \
+  --cap-add=IPC_LOCK \
+  --ipc host \
   --gpus all \
   --entrypoint /usr/local/bin/vllm \
   -e VLLM_TARGET_DEVICE=cuda \
@@ -44,7 +57,7 @@ exec docker run --rm \
     --served-model-name montimage-dgx-spark "${MODEL_ID}" \
     --host 127.0.0.1 --port "${PORT}" \
     --tensor-parallel-size 1 \
-    --trust-remote-code   # required: custom MoE backend model architecture \
+    --trust-remote-code \
     --moe-backend auto \
     --gpu-memory-utilization "${UTIL}" \
     --linear-backend flashinfer_b12x \
@@ -61,6 +74,5 @@ exec docker run --rm \
     --default-chat-template-kwargs '{"enable_thinking":true,"preserve_thinking":true}' \
     --tool-call-parser qwen3_coder \
     --enable-auto-tool-choice \
-    --limit-mm-per-prompt '{"image":4}' \
-    --allowed-media-domains "" \
+    --limit-mm-per-prompt '{"image":0}' \
     --override-generation-config '{"temperature":0.6,"top_p":0.95,"top_k":20,"min_p":0.0}'

--- a/tests/test_agentic_env.py
+++ b/tests/test_agentic_env.py
@@ -9,8 +9,7 @@ import unittest
 sys.path.insert(0, __import__("os").path.dirname(__import__("os").path.dirname(
     __import__("os").path.abspath(__file__))))
 
-from benchkit.agentic import env  # noqa: E402
-
+from benchkit.agentic import env
 
 # ---------------------------------------------------------------------------
 # Workspace bookkeeping

--- a/tests/test_agentic_loop.py
+++ b/tests/test_agentic_loop.py
@@ -12,8 +12,7 @@ from unittest import mock
 sys.path.insert(0, __import__("os").path.dirname(__import__("os").path.dirname(
     __import__("os").path.abspath(__file__))))
 
-from benchkit.agentic import loop  # noqa: E402
-
+from benchkit.agentic import loop
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/tests/test_agentic_tasks_hard.py
+++ b/tests/test_agentic_tasks_hard.py
@@ -9,8 +9,8 @@ import unittest
 sys.path.insert(0, __import__("os").path.dirname(__import__("os").path.dirname(
     __import__("os").path.abspath(__file__))))
 
-from benchkit.agentic.env import Workspace  # noqa: E402
-from benchkit.agentic.tasks_hard import TASKS  # noqa: E402
+from benchkit.agentic.env import Workspace
+from benchkit.agentic.tasks_hard import TASKS
 
 
 class CountingWorkspace(Workspace):

--- a/tests/test_compare_dispatch.py
+++ b/tests/test_compare_dispatch.py
@@ -20,7 +20,7 @@ import unittest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from benchkit import cli  # noqa: E402
+from benchkit import cli
 
 AGENTIC_SUMMARY = dict(
     kind="agentic", pass_at_1=0.5, agent_score=0.4, mean_efficiency=0.8,

--- a/tests/test_harness_models.py
+++ b/tests/test_harness_models.py
@@ -11,7 +11,7 @@ import unittest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from benchkit.harness import HARNESSES, HarnessConfig, get, models  # noqa: E402
+from benchkit.harness import HARNESSES, HarnessConfig, get, models
 
 CATALOGUE = [
     ("anthropic", "claude-sonnet-4-5"),

--- a/tests/test_harness_staged_config_race.py
+++ b/tests/test_harness_staged_config_race.py
@@ -22,9 +22,9 @@ from unittest import mock
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from benchkit.harness import HarnessConfig, HarnessResult, get  # noqa: E402
-from benchkit.harness.claudecode import CONFIG_DIR as CLAUDE_HOME  # noqa: E402
-from benchkit.harness.opencode import CONFIG_NAME  # noqa: E402
+from benchkit.harness import HarnessConfig, HarnessResult, get
+from benchkit.harness.claudecode import CONFIG_DIR as CLAUDE_HOME
+from benchkit.harness.opencode import CONFIG_NAME
 
 ENDPOINT = "http://localhost:8001/v1"
 

--- a/tests/test_harness_staged_config_race.py
+++ b/tests/test_harness_staged_config_race.py
@@ -22,7 +22,7 @@ from unittest import mock
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from benchkit.harness import HarnessConfig, get  # noqa: E402
+from benchkit.harness import HarnessConfig, HarnessResult, get  # noqa: E402
 from benchkit.harness.claudecode import CONFIG_DIR as CLAUDE_HOME  # noqa: E402
 from benchkit.harness.opencode import CONFIG_NAME  # noqa: E402
 
@@ -31,10 +31,18 @@ ENDPOINT = "http://localhost:8001/v1"
 TASKS = 8
 
 
-class _FakeProcess:
-    stdout = ""
-    stderr = ""
-    returncode = 0
+# The adapters spawn through stream_events(), not subprocess.run(): af32cbe
+# moved them to Popen so task logs stream instead of buffering. Patching
+# subprocess.run here caught nothing and let the real `opencode`/`claude`
+# binaries run, so patch the seam the adapters actually call. It takes
+# (argv, cwd=, env=, handler=, timeout=, label=) and returns
+# (HarnessResult, returncode, stderr_tail).
+OPENCODE_SPAWN = "benchkit.harness.opencode.stream_events"
+CLAUDECODE_SPAWN = "benchkit.harness.claudecode.stream_events"
+
+
+def fake_spawn(*_argv, **_kw):
+    return HarnessResult(stop_reason="done"), 0, ""
 
 
 class StagedPathCase(unittest.TestCase):
@@ -57,6 +65,8 @@ class StagedPathCase(unittest.TestCase):
 
 
 class TestOpenCodeStaging(StagedPathCase):
+    SPAWN = OPENCODE_SPAWN
+
     def harness(self):
         return get("opencode", HarnessConfig(model="m", base_url=ENDPOINT))
 
@@ -66,7 +76,7 @@ class TestOpenCodeStaging(StagedPathCase):
         w1 = h.prepare(first)
         w2 = h.prepare(second)
         seen = {}
-        with mock.patch("subprocess.run", return_value=_FakeProcess()) as run:
+        with mock.patch(self.SPAWN, side_effect=fake_spawn) as run:
             h.run(w1, "p")
             h.run(w2, "p")
             seen[w1] = run.call_args_list[0].kwargs["env"]["OPENCODE_CONFIG"]
@@ -93,10 +103,10 @@ class TestOpenCodeStaging(StagedPathCase):
             barrier.wait(timeout=30)
             with lock:
                 handed[kw["cwd"]] = kw["env"].get("OPENCODE_CONFIG")
-            return _FakeProcess()
+            return HarnessResult(stop_reason="done"), 0, ""
 
         before = dict(vars(h))
-        with mock.patch("subprocess.run", side_effect=fake_run):
+        with mock.patch(self.SPAWN, side_effect=fake_run):
             with ThreadPoolExecutor(max_workers=TASKS) as ex:
                 list(ex.map(lambda w: h.run(w, "p"), workdirs))
 
@@ -126,9 +136,12 @@ class TestOpenCodeStaging(StagedPathCase):
         container, = self.containers(1)
         workdir = h.prepare(container)
         shutil.rmtree(container)
-        with mock.patch("subprocess.run",
-                        side_effect=AssertionError("must not be invoked")):
+        # run() catches every exception from the spawn and turns it into an
+        # error result, so a raising double would be swallowed and prove
+        # nothing. Assert the spawn was never reached at all.
+        with mock.patch(self.SPAWN, side_effect=fake_spawn) as run:
             h.run(workdir, "p")
+        run.assert_not_called()
 
     def test_without_an_endpoint_nothing_is_redirected(self):
         h = get("opencode", HarnessConfig(provider="ollama", model="m"))
@@ -137,13 +150,15 @@ class TestOpenCodeStaging(StagedPathCase):
         self.assertFalse(os.path.exists(self.staged_path(workdir, CONFIG_NAME)),
                          "endpoint-less runs must stage no config")
         seen = {}
-        with mock.patch("subprocess.run", return_value=_FakeProcess()) as run:
+        with mock.patch(self.SPAWN, side_effect=fake_spawn) as run:
             h.run(workdir, "p")
             seen["env"] = run.call_args.kwargs["env"]
         self.assertNotIn("OPENCODE_CONFIG", seen["env"])
 
 
 class TestClaudeCodeStaging(StagedPathCase):
+    SPAWN = CLAUDECODE_SPAWN
+
     def harness(self):
         return get("claude-code", HarnessConfig(model="sonnet",
                                                 base_url=ENDPOINT))
@@ -168,9 +183,9 @@ class TestClaudeCodeStaging(StagedPathCase):
             barrier.wait(timeout=30)
             with lock:
                 handed[kw["cwd"]] = kw["env"].get("CLAUDE_CONFIG_DIR")
-            return _FakeProcess()
+            return HarnessResult(stop_reason="done"), 0, ""
 
-        with mock.patch("subprocess.run", side_effect=fake_run):
+        with mock.patch(self.SPAWN, side_effect=fake_run):
             with ThreadPoolExecutor(max_workers=TASKS) as ex:
                 list(ex.map(lambda w: h.run(w, "p"), workdirs))
 
@@ -186,7 +201,7 @@ class TestClaudeCodeStaging(StagedPathCase):
         container, = self.containers(1)
         workdir = h.prepare(container)
         seen = {}
-        with mock.patch("subprocess.run", return_value=_FakeProcess()) as run:
+        with mock.patch(self.SPAWN, side_effect=fake_spawn) as run:
             h.run(workdir, "p")
             seen["env"] = run.call_args.kwargs["env"]
         self.assertNotIn("CLAUDE_CONFIG_DIR", seen["env"])

--- a/tests/test_harness_stream.py
+++ b/tests/test_harness_stream.py
@@ -21,15 +21,18 @@ import unittest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from benchkit.harness import HarnessConfig  # noqa: E402
-from benchkit.harness.claudecode import (  # noqa: E402
-    _claudecode_finalize, _claudecode_handler, parse_events as parse_claude)
-from benchkit.harness.opencode import (  # noqa: E402
-    OpenCodeHarness, _opencode_handler, parse_events as parse_opencode)
-from benchkit.harness.pi import (  # noqa: E402
-    PiHarness, _pi_handler, parse_events as parse_pi)
-from benchkit.harness.stream import RAW_TAIL_CHARS, StreamTimeout  # noqa: E402
-from benchkit.harness.stream import stream_events  # noqa: E402
+from benchkit.harness import HarnessConfig
+from benchkit.harness.claudecode import _claudecode_finalize, _claudecode_handler
+from benchkit.harness.claudecode import parse_events as parse_claude
+from benchkit.harness.opencode import OpenCodeHarness, _opencode_handler
+from benchkit.harness.opencode import parse_events as parse_opencode
+from benchkit.harness.pi import PiHarness, _pi_handler
+from benchkit.harness.pi import parse_events as parse_pi
+from benchkit.harness.stream import (
+    RAW_TAIL_CHARS,
+    StreamTimeout,
+    stream_events,
+)
 
 PY = sys.executable
 

--- a/tests/test_launcher_scripts.py
+++ b/tests/test_launcher_scripts.py
@@ -1,0 +1,200 @@
+"""Regression guards for the vLLM launcher scripts (start-*.sh, configs/*.sh).
+
+These scripts are the deployment artifact: `./bench apply` copies one into place
+and systemd execs it. Nothing in CI used to run or lint them, so a launcher that
+could not even assemble its own `docker run` shipped to main.
+
+On 2026-08-24 that cost the endpoint a morning. Commit 87e784c added an inline
+comment to a backslash-continued line:
+
+    --network host   # required: vLLM needs host networking for GPU direct \\
+
+The `#` comment swallows the backslash, so the command ends there and docker is
+invoked with no IMAGE argument. `vllm-qwen.service` crash-looped ~600 times and
+`montimage-dgx-spark` vanished from /v1/models. `bash -n` does not catch this --
+the script is syntactically valid, just truncated -- so the real check is
+`test_docker_run_is_complete`, which executes each launcher against a fake
+`docker` and inspects the argv that actually comes out. That catches any cause
+of truncation, not only this one.
+"""
+
+import os
+import re
+import stat
+import subprocess
+import tempfile
+import unittest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Launchers that build a `docker run ... serve <model>` vLLM invocation.
+VLLM_LAUNCHERS = [
+    "serve-qwen38-4bit.sh",
+    "start-gemma.sh",
+    "start-qwen.sh",
+    "configs/gemma4-12b-w4a16.sh",
+    "configs/ornith-1.5-35b-a3b-nvfp4.sh",
+    "configs/qwen3.6-35b-a3b-nvfp4.sh",
+    "configs/qwen3.8-27b-nvfp4-dspark.sh",
+    "configs/qwen3.8-27b-nvfp4-tunable.sh",
+]
+
+# A `#` comment here eats the line continuation and truncates the command.
+INLINE_COMMENT_ON_CONTINUED_LINE = re.compile(r"^\s*\S.*\s#\s.*\\$")
+
+# Prints its argv NUL-separated for `docker run`, and stays silent otherwise so
+# the `docker ps` readiness polls in the detached launchers fall through fast.
+DOCKER_SHIM = """#!/bin/sh
+if [ "$1" = "run" ]; then
+  : > "$DOCKER_ARGV_FILE"
+  for a in "$@"; do printf '%s\\0' "$a" >> "$DOCKER_ARGV_FILE"; done
+fi
+exit 0
+"""
+
+
+def all_shell_scripts():
+    """Every tracked *.sh in the repo, as paths relative to REPO_ROOT."""
+    out = subprocess.run(
+        ["git", "ls-files", "*.sh"],
+        cwd=REPO_ROOT, capture_output=True, text=True, check=True,
+    )
+    return [p for p in out.stdout.split("\n") if p]
+
+
+class TestShellScriptSyntax(unittest.TestCase):
+    """Cheap static checks that apply to every shell script in the repo."""
+
+    def test_scripts_are_found(self):
+        """Guard the guard: an empty file list would make every test vacuous."""
+        self.assertGreaterEqual(len(all_shell_scripts()), len(VLLM_LAUNCHERS))
+
+    def test_bash_syntax(self):
+        for rel in all_shell_scripts():
+            with self.subTest(script=rel):
+                proc = subprocess.run(
+                    ["bash", "-n", os.path.join(REPO_ROOT, rel)],
+                    capture_output=True, text=True, check=False,
+                )
+                self.assertEqual(proc.returncode, 0, proc.stderr)
+
+    def test_no_inline_comment_on_continued_line(self):
+        """`flag  # why \\` — the comment eats the backslash (shellcheck SC1143)."""
+        for rel in all_shell_scripts():
+            path = os.path.join(REPO_ROOT, rel)
+            with open(path, encoding="utf-8") as f:
+                for lineno, line in enumerate(f, start=1):
+                    line = line.rstrip("\n")
+                    if INLINE_COMMENT_ON_CONTINUED_LINE.match(line):
+                        self.fail(
+                            f"{rel}:{lineno} has an inline comment on a "
+                            f"continued line, which swallows the backslash and "
+                            f"truncates the command:\n    {line}\n"
+                            f"Move the comment above the command instead."
+                        )
+
+    def test_no_comment_line_inside_continued_command(self):
+        """A comment on its own line inside a continued command truncates it too."""
+        for rel in all_shell_scripts():
+            path = os.path.join(REPO_ROOT, rel)
+            with open(path, encoding="utf-8") as f:
+                lines = [line.rstrip("\n") for line in f]
+            for lineno, line in enumerate(lines[1:], start=2):
+                previous = lines[lineno - 2]
+                if previous.rstrip().endswith("\\") and line.lstrip().startswith("#"):
+                    self.fail(
+                        f"{rel}:{lineno} is a comment inside a continued "
+                        f"command, which ends it early:\n    {line}\n"
+                        f"Move the comment above the command instead."
+                    )
+
+
+class TestVllmLaunchersAssemble(unittest.TestCase):
+    """Run each launcher against a fake docker and inspect the real argv."""
+
+    def _capture_docker_run(self, rel):
+        """Execute *rel* with a shimmed docker; return the `docker run` argv."""
+        with tempfile.TemporaryDirectory() as tmp:
+            shim_dir = os.path.join(tmp, "bin")
+            os.makedirs(shim_dir)
+            shim = os.path.join(shim_dir, "docker")
+            with open(shim, "w", encoding="utf-8") as f:
+                f.write(DOCKER_SHIM)
+            os.chmod(shim, os.stat(shim).st_mode | stat.S_IEXEC | stat.S_IXGRP)
+
+            argv_file = os.path.join(tmp, "argv")
+            env = dict(os.environ)
+            env.update({
+                "PATH": shim_dir + os.pathsep + env["PATH"],
+                "DOCKER_ARGV_FILE": argv_file,
+                # Keep every host path the scripts mkdir inside the sandbox.
+                "HF_HOME_DIR": os.path.join(tmp, "hf"),
+                "HF_CACHE": os.path.join(tmp, "hf"),
+                "VLLM_CACHE": os.path.join(tmp, "vllm"),
+                "VLLM_CACHE_DIR": os.path.join(tmp, "vllm"),
+            })
+            subprocess.run(
+                ["bash", os.path.join(REPO_ROOT, rel)],
+                env=env, capture_output=True, text=True, timeout=120, check=False,
+            )
+            self.assertTrue(
+                os.path.exists(argv_file),
+                f"{rel} never reached `docker run` at all",
+            )
+            with open(argv_file, encoding="utf-8") as f:
+                # Each arg is NUL-terminated, so the split leaves one trailing
+                # empty element. Drop only that one: an empty *argument* is
+                # meaningful here (`--allowed-media-domains ""` is the bug).
+                raw = f.read().split("\0")
+                self.assertEqual(raw[-1], "")
+                return raw[:-1]
+
+    def test_docker_run_is_complete(self):
+        """Each launcher must reach `docker run` with an IMAGE before `serve`.
+
+        This is the check that would have caught the 2026-08-24 truncation.
+        """
+        for rel in VLLM_LAUNCHERS:
+            with self.subTest(script=rel):
+                argv = self._capture_docker_run(rel)
+                self.assertEqual(argv[0], "run")
+                self.assertIn(
+                    "serve", argv,
+                    f"{rel}: `docker run` argv has no `serve` subcommand, so "
+                    f"the command was truncated: {argv}",
+                )
+                image = argv[argv.index("serve") - 1]
+                self.assertFalse(
+                    image.startswith("-"),
+                    f"{rel}: expected an IMAGE before `serve`, got the flag "
+                    f"{image!r}; the command is truncated or misordered",
+                )
+                self.assertRegex(
+                    image, r"^[A-Za-z0-9][\w.\-/]*(:[\w.\-]+|@sha256:[0-9a-f]{64})$",
+                    f"{rel}: {image!r} does not look like an image reference",
+                )
+
+    def test_no_empty_allowed_media_domains(self):
+        """`--allowed-media-domains ""` makes vLLM refuse to start.
+
+        vLLM parses the empty string as [None] and pydantic rejects it, so the
+        server dies at startup. Multimodal is disabled with
+        `--limit-mm-per-prompt '{"image":0}'` instead, which also removes the
+        SSRF surface (F-SEC-002) rather than merely narrowing it.
+        """
+        for rel in VLLM_LAUNCHERS:
+            with self.subTest(script=rel):
+                argv = self._capture_docker_run(rel)
+                if "--allowed-media-domains" not in argv:
+                    continue
+                value = argv[argv.index("--allowed-media-domains") + 1]
+                self.assertNotEqual(
+                    value, "",
+                    f"{rel}: --allowed-media-domains \"\" is rejected by vLLM at "
+                    f"startup; disable multimodal with --limit-mm-per-prompt "
+                    f"'{{\"image\":0}}' or name an explicit host allowlist",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pi_endpoint.py
+++ b/tests/test_pi_endpoint.py
@@ -16,8 +16,8 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from benchkit.harness import HarnessConfig, get  # noqa: E402
-from benchkit.harness.pi import (  # noqa: E402
+from benchkit.harness import HarnessConfig, get
+from benchkit.harness.pi import (
     CATALOGUE_NAME,
     DEFAULT_ENDPOINT_PROVIDER,
     STAGED_AGENT_DIR,
@@ -199,7 +199,7 @@ class _ModelsHandler(BaseHTTPRequestHandler):
 
     served = ["served-model"]
 
-    def do_GET(self):  # noqa: N802 — BaseHTTPRequestHandler's name
+    def do_GET(self):
         body = json.dumps({"data": [{"id": i} for i in self.served]}).encode()
         self.send_response(200)
         self.send_header("content-type", "application/json")

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -27,10 +27,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from aiohttp import web  # noqa: E402
-from aiohttp.test_utils import TestClient, TestServer  # noqa: E402
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
 
-import router  # noqa: E402
+import router
 
 
 class TestDefaultListenHost(unittest.TestCase):

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -16,8 +16,8 @@ import unittest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from benchkit import report, sweep  # noqa: E402
-from benchkit import serving as real_serving  # noqa: E402
+from benchkit import report, sweep
+from benchkit import serving as real_serving
 
 SUMMARY = dict(
     kind="agentic", pass_at_1=0.5, agent_score=0.4, mean_efficiency=0.8,


### PR DESCRIPTION
Closes #75

## What broke

`montimage-dgx-spark` was down this morning: `vllm-qwen.service` crash-looped ~600 times over 2.5 hours and the router served an empty `/v1/models`.

`start-qwen.sh` and three `configs/*.sh` recipes could not assemble their own `docker run`. Commit 87e784c added an inline comment to each backslash-continued line:

```bash
--network host   # required: vLLM needs host networking for GPU direct \
```

The `#` comment swallows the trailing backslash, so the command ends at `--network host` and docker is invoked with no IMAGE argument:

```
docker: 'docker run' requires at least 1 argument
```

Every comment now sits in a note block above the command, keyed to the flag it explains. Comments cannot live inside a `\`-continued command at all — trailing or on their own line.

## The second bug underneath

Fixing that exposed a second failure from the same commit: vLLM parses `--allowed-media-domains ""` as `[None]` and pydantic refuses to start the server. The flag never worked, and bug #1 meant vLLM was never reached, so nobody noticed.

\#24 wanted multimodal disabled (F-SEC-002). `--limit-mm-per-prompt '{"image":0}'` actually achieves it — media is rejected at the request boundary, so no URL is ever fetched, which is strictly stronger than a domain allowlist.

> [!IMPORTANT]
> **This disables vision input.** The previously running container had `image:4` with no domain restriction. To restore vision: set `image:N` and add `--allowed-media-domains` with an explicit host allowlist — don't just omit it, the default allows every domain.

## Why CI didn't catch it

These launchers are the deployment artifact — `./bench apply` copies one into place and systemd execs it — but nothing in CI ran or linted them, so a launcher that could not start shipped to main. Two guards:

- **`tests/test_launcher_scripts.py`** executes all 8 vLLM launchers against a fake `docker` on PATH and asserts an IMAGE lands before `serve`. This is the load-bearing check: `bash -n` cannot catch truncation (the script stays valid, just short), and inspecting the real argv catches *any* cause, not only inline comments. Also rejects both comment patterns and `--allowed-media-domains ""`.
- **shellcheck** over every tracked `*.sh` in CI. It flags this as SC2215 on the exact line, and current scripts are clean at `--severity=warning`.

Both guards are mutation-verified: reintroducing either original bug fails the corresponding test.

## Second commit: repairing the harness staging tests

`tests/test_harness_staged_config_race.py` was already failing on `main` (2 failures, 3 errors) — confirmed pre-existing in a pristine worktree at HEAD, unrelated to the launchers.

It patched `subprocess.run`, but af32cbe moved both adapters to `Popen` via `stream_events()`. The mock bound to nothing, and the tests that "passed" passed only because `opencode`/`claude` were absent — `run()` catches every exception from the spawn and turns it into an error result, so a missing binary looked like a clean run. On a machine with those binaries on PATH, the suite was really shelling out to them.

`test_a_missing_staged_config_never_runs_opencode` was the clearest casualty: it asserted by raising `AssertionError` from the double, which `run()` would have swallowed even if the patch had bound. It now asserts the spawn was never called.

Now patches `benchkit.harness.{opencode,claudecode}.stream_events` and returns the `(HarnessResult, rc, stderr_tail)` triple it contracts. **Assertions are unchanged.** Mutation-verified: reintroducing the #61 bug fails both staging tests again. Module runtime went from 10.4s to 0.008s.

## Verification

Endpoint recovered and confirmed serving:

```
/health    → {"status": "ok", "backends": {"montimage-dgx-spark": "ok"}}
/v1/models → montimage-dgx-spark (unsloth/Qwen3.6-35B-A3B-NVFP4, max_model_len 262144)
chat       → "READY"
```

Full CI parity locally, on the pinned toolchain:

| Step | Result |
|---|---|
| ruff 0.6.9 | All checks passed |
| mypy 1.11.2 | no issues, 26 source files |
| unittest | 269 tests, OK |
| `bench validate` | 28/28 |
| `bench validate --suite agentic-all` | 16/16 |
| shellcheck | clean |

No restart was needed — the unit was already in its auto-restart loop and picked up the fixed script itself.

## Not addressed here

Only 3 of 8 launchers are digest-pinned, though 78d6b2a claims "#25 pin vLLM image by SHA-256 digest in **all** launchers": `start-gemma.sh` and `configs/gemma4-12b-w4a16.sh` use `mia-vllm-gb10-gemma:latest`, and `serve-qwen38-4bit.sh` / `qwen3.8-27b-nvfp4-*` use `vllm/vllm-openai:v0.27.1-aarch64`. Separate concern from this outage, and digest-pinning a locally-built `:latest` image isn't meaningful the same way — flagging it as a real gap against #25's stated scope.