### PR TITLE
feat(harness): benchmark any live harness setup end-to-end (#76)

### DIFF
--- a/.opencode/command/bench-setup.md
+++ b/.opencode/command/bench-setup.md
@@ -1,0 +1,19 @@
+---
+description: Benchmark opencode's live configuration (plugins, MCP servers included) and get a scored report with improvement suggestions
+---
+
+Benchmark this harness's live setup with the repo's own tooling. From
+`/home/montimage/buildspace/dgx-spark-llm-lab`, run:
+
+```bash
+./bench setup --harness opencode --suite agentic-hard
+```
+
+Add `-m <provider/model>` to pick a model, `--samples 2` for a steadier score,
+`--thinking` for reasoning mode. It takes several minutes per sample and runs
+model-generated code on this host.
+
+Then read the printed report path (`results/<date>/REPORT-live*.md`) and relay
+the headline numbers (agent score, solve rate, calls vs par) plus every bullet
+of the **Suggestions** section. Live mode keeps plugins and MCP servers
+enabled — if any can call another model, the measurement is contaminated by it.

--- a/.pi/skills/bench-setup/SKILL.md
+++ b/.pi/skills/bench-setup/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: bench-setup
+description: Benchmark this harness's live configuration (skills, MCP servers, settings included) and get a scored report with improvement suggestions
+---
+
+# Benchmark the live setup
+
+Run the repo's benchmark against *this* harness exactly as it is configured
+right now — extensions, skills and MCP servers included, nothing isolated.
+
+From the repository root (`/home/montimage/buildspace/dgx-spark-llm-lab`), run:
+
+```bash
+./bench setup --harness pi --suite agentic-hard
+```
+
+- Add `-m <provider/model>` only if you want a specific model; otherwise the
+  run asks (or use BENCH_HARNESS_MODEL).
+- Add `--samples 2` for a less noisy score; add `--thinking` to test the
+  reasoning mode.
+- The run takes several minutes per sample and executes model-generated code
+  on this host.
+
+When it finishes:
+
+1. Read the report path it prints (`results/<date>/REPORT-live*.md`) and open it.
+2. Relay the headline numbers (agent score, solve rate, mean calls vs par) and
+   every bullet in the **Suggestions** section back to the user, verbatim where
+   possible.
+
+Note the caveat from the report: live mode keeps your real setup enabled, so if
+any extension or MCP server can call another model, those numbers are
+contaminated by that model.

--- a/benchkit/advice.py
+++ b/benchkit/advice.py
@@ -1,0 +1,126 @@
+"""Actionable suggestions from a run's own numbers — no model calls, pure heuristics.
+
+`bench setup run` (issue #76) measures a live harness setup and then has to say
+something *useful* about it. The signals already exist in every summary:
+`summarize()` in benchkit/agentic/loop.py and the fields the harness runner adds
+(`mean_input_tokens`, the `harness` describe block). This module reads those and
+emits Markdown suggestions, each tied to the number that triggered it.
+
+Every rule is deliberately conservative: it fires on a threshold crossed, not on
+a vibe, and it always names the metric so the reader can check it.
+"""
+
+#: mean input tokens per task above which context bloat is worth calling out.
+#: A harness resends its whole context every turn; skills and MCP servers are
+#: billed through this number even when they never help solve anything.
+INPUT_TOKEN_BLOAT = 50_000
+
+#: valid-call rate below which tool schemas are probably mismatched
+LOW_VALID_RATE = 0.90
+
+#: solved tasks using more than this multiple of par are wasting turns
+INEFFICIENCY_RATIO = 1.5
+
+#: reasoning tokens per task that suggest the thinking budget dominates
+REASONING_TOKEN_HEAVY = 8_000
+
+
+def build(summary):
+    """Markdown suggestion bullets for one agentic summary dict.
+
+    Returns [] when nothing crosses a threshold — silence is better than
+    padding a good run with filler.
+    """
+    s = summary
+    tips: list[str] = []
+    live = _is_live(s)
+
+    ins = s.get("mean_input_tokens")
+    if ins and ins > INPUT_TOKEN_BLOAT:
+        tips.append(
+            f"Mean input tokens is **{ins:,.0f} per task** — context is being "
+            "resent every turn. In a "
+            + ("live setup, audit installed **skills and MCP servers**: each "
+               "one's prompt/schema rides along on every call even when unused. "
+               "Disable what this work does not need."
+               if live else
+               "harness, check system-prompt size and how much history is "
+               "resend per turn."))
+
+    if s.get("hit_turn_limit"):
+        tips.append(
+            f"**{s['hit_turn_limit']} task(s) hit the turn limit** without "
+            "finishing. Either the budget is too small for this suite or the "
+            "harness is missing a tool the tasks need — check which tools the "
+            "harness exposes against what the tasks require.")
+
+    if s.get("stalled_no_tool_call"):
+        tips.append(
+            f"**{s['stalled_no_tool_call']} task(s) stalled with no tool call**. "
+            "That usually means the model replied in prose where a tool was "
+            "expected — often a chat-template or tool-call-parser mismatch "
+            "rather than model inability.")
+
+    rate = s.get("valid_call_rate")
+    if rate is not None and rate < LOW_VALID_RATE:
+        tips.append(
+            f"Valid tool-call rate is **{rate * 100:.1f} %** — many calls error. "
+            "Check the harness's tool-call parser / schema wiring against the "
+            "model's expected format before blaming the model.")
+
+    par, calls = s.get("mean_par_calls"), s.get("mean_tool_calls")
+    if par and calls and calls > par * INEFFICIENCY_RATIO:
+        tips.append(
+            f"Tasks use **{calls:.1f} tool calls against a par of {par:.1f}**. "
+            "In a live setup, verbose skills or an over-eager MCP server can "
+            "push the agent into exploratory calls; trimming instructions "
+            "usually recovers most of the gap.")
+
+    reas = s.get("mean_reasoning_tokens")
+    if reas and reas > REASONING_TOKEN_HEAVY:
+        tips.append(
+            f"Mean reasoning tokens is **{reas:,.0f} per task** — thinking "
+            "dominates the wall-clock. Consider a lower thinking level for "
+            "tool-loop work unless accuracy demands it.")
+
+    errs = s.get("errored")
+    if errs:
+        tips.append(
+            f"**{errs} generation(s) errored** outright. Check the harness "
+            "block's `detail` field in the result file — an adapter-level "
+            "failure is a wiring problem, not a model failure.")
+
+    hard = (s.get("by_difficulty") or {}).get("hard")
+    easy = (s.get("by_difficulty") or {}).get("easy")
+    if hard is not None and easy is not None and easy - hard > 0.4:
+        tips.append(
+            f"Hard-task solve rate (**{hard * 100:.0f} %**) trails easy tasks "
+            f"({easy * 100:.0f} %) by a wide margin — the ceiling here is "
+            "capability, not configuration. More samples will not close it.")
+
+    if live:
+        tips.append(
+            "This was a **live-mode** run of your daily setup: extensions, "
+            "skills and MCP servers were enabled. Any component that can call "
+            "another model contaminates these numbers — see the caveats section.")
+    return tips
+
+
+def section(summary, title="Suggestions"):
+    """The full Markdown section, or [] when there is nothing to suggest."""
+    tips = build(summary)
+    if not tips:
+        return [f"## {title}\n", "Nothing crossed a threshold — the setup looks "
+                "healthy on every signal measured.\n"]
+    out = [f"## {title}\n"]
+    out.extend(f"- {t}" for t in tips)
+    out.append("")
+    return out
+
+
+def _is_live(summary):
+    """Was this run in live mode? Read from either place it may be stamped."""
+    cfg = summary.get("config") or {}
+    if cfg.get("extra", {}).get("live") or cfg.get("live"):
+        return True
+    return bool((summary.get("harness") or {}).get("live"))

--- a/benchkit/cli.py
+++ b/benchkit/cli.py
@@ -393,17 +393,22 @@ def _harness_pick(args, endpoint):
     return hmodels.pick(args.harness, entries)
 
 
-def _harness_config(args, h, base_url):
+def _harness_config(args, h, base_url, live=False):
     """The Config one harness run records, label included."""
     cfg = runner.Config(base_url=base_url, model=h.model_spec,
                         label=args.label, thinking=args.thinking, max_tokens=0,
                         samples=args.samples, concurrency=args.concurrency,
                         test_timeout=args.test_timeout)
+    if live:
+        # Stamp live mode on the run config so a report can tell a measurement
+        # of the user's daily setup from one of an isolated harness (#76).
+        cfg.extra["live"] = True
     if not cfg.label:
         # The model belongs in the label: two runs of the same harness on
         # different models are the whole point, and a file named after the
         # harness alone would overwrite one with the other.
-        cfg.label = (f"{h.name} {_slug(str(h.model_spec))} "
+        cfg.label = (f"{h.name} {'live ' if live else ''}"
+                     f"{_slug(str(h.model_spec))} "
                      f"think-{'ON' if args.thinking else 'OFF'}")
     return cfg
 
@@ -424,13 +429,14 @@ def _print_harness_summary(h, summary):
     print("=" * 64)
 
 
-def _harness_run(args, endpoint):
+def _harness_run(args, endpoint, live=False):
     from benchkit import harness as H
     from benchkit.harness import runner as hrunner
 
     provider, model = _harness_pick(args, endpoint)
     h = H.get(args.harness,
-              H.HarnessConfig(provider=provider, model=model, base_url=endpoint))
+              H.HarnessConfig(provider=provider, model=model, base_url=endpoint,
+                              live=live))
     tasks = get(args.suite)
     if kind(args.suite) != "agentic":
         raise SystemExit("harness runs need an agentic suite "
@@ -439,8 +445,9 @@ def _harness_run(args, endpoint):
     if not ok:
         raise SystemExit(f"harness {h.name!r} is not usable here: {detail}")
 
-    cfg = _harness_config(args, h, endpoint or "(harness)")
-    print(f"harness={h.name}  {detail}\nsuite={args.suite} ({len(tasks)} tasks)  "
+    cfg = _harness_config(args, h, endpoint or "(harness)", live=live)
+    print(f"harness={h.name}{'+live' if live else ''}  {detail}\n"
+          f"suite={args.suite} ({len(tasks)} tasks)  "
           f"{cfg.label}  samples={cfg.samples} concurrency={cfg.concurrency}\n", flush=True)
 
     summary, results = hrunner.run(h, tasks, cfg, on_result=_print_agentic,
@@ -453,7 +460,32 @@ def _harness_run(args, endpoint):
 
     _print_harness_summary(h, summary)
     print(f"\nwritten to {out}")
+    if live:
+        # A live run is judged on its own setup, so the advice section is part
+        # of the deliverable, not an extra step. Same append-only rule as the
+        # result json: never overwrite a report from an earlier campaign.
+        md = report.build([report.load(out)], title=f"Live setup: {h.name}",
+                          question=(f"Is {h.name}'s current setup any good, and "
+                                    f"what should improve?"),
+                          verdict=None, advice=True)
+        rpt = os.path.join(os.path.dirname(out), "REPORT-live.md")
+        rpt = _ensure_unique_path(rpt)
+        with open(rpt, "w") as f:
+            f.write(md)
+        print(f"report written to {rpt}")
     return 0
+
+
+def cmd_setup(args):
+    """Benchmark the harness you are sitting in, with its live configuration.
+
+    `bench harness run` isolates: no extensions, no skills, no MCP servers, so
+    the model alone is measured. `bench setup` is the opposite — the user's
+    daily setup runs exactly as they experience it (issue #76), and the report
+    ends with concrete suggestions about that setup.
+    """
+    endpoint = args.endpoint or os.environ.get("BENCH_HARNESS_ENDPOINT") or None
+    return _harness_run(args, endpoint, live=True)
 
 
 def cmd_configs(args):
@@ -657,6 +689,37 @@ def _parser_harness(sub):
     s.set_defaults(func=cmd_harness)
 
 
+def _parser_setup(sub):
+    """`bench setup` — benchmark the harness's live, as-used configuration."""
+    s = sub.add_parser("setup",
+                       help="benchmark a harness with its live configuration "
+                            "(skills, MCP servers, settings included) and get "
+                            "improvement suggestions")
+    s.add_argument("setup_cmd", nargs="?", default="run", choices=["run"],
+                   help="run the live-setup benchmark")
+    s.add_argument("--harness", default="pi",
+                   help="which harness to drive: " + ", ".join(_harness_names()))
+    s.add_argument("--model", "-m", dest="model", default="",
+                   help="model to benchmark, as <provider>/<model> or any unique "
+                        "part of it (default: BENCH_HARNESS_MODEL, else ask; the "
+                        "harness's own default model is usually what you want)")
+    s.add_argument("--provider", help="restrict --model to one provider")
+    s.add_argument("--endpoint", default="",
+                   help="optional endpoint for the model itself; the harness's "
+                        "live configuration is still used unchanged")
+    s.add_argument("--suite", default="agentic-hard", choices=list(SUITES))
+    s.add_argument("--samples", type=int, default=1)
+    s.add_argument("--concurrency", type=int, default=2)
+    s.add_argument("--thinking", action="store_true")
+    s.add_argument("--timeout", type=int, default=900, help="seconds per task")
+    s.add_argument("--test-timeout", type=int, default=60)
+    s.add_argument("--label", default="")
+    s.add_argument("--out")
+    s.add_argument("--keep-dirs", action="store_true",
+                   help="leave each task's working directory on disk for inspection")
+    s.set_defaults(func=cmd_setup)
+
+
 def _parser_configs(sub):
     s = sub.add_parser("configs", help="list known-good serving configs")
     s.set_defaults(func=cmd_configs)
@@ -682,6 +745,7 @@ def _build_parser():
     _parser_compare(sub)
     _parser_sweep(sub)
     _parser_harness(sub)
+    _parser_setup(sub)
     _parser_configs(sub)
     _parser_apply(sub)
     return p

--- a/benchkit/cli.py
+++ b/benchkit/cli.py
@@ -8,9 +8,9 @@ import sys
 HERE = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, HERE)
 
-from benchkit import report, runner
-from benchkit.references import REFERENCES
-from benchkit.suites import DESCRIPTIONS, SUITES, get, kind
+from benchkit import report, runner  # noqa: E402
+from benchkit.references import REFERENCES  # noqa: E402
+from benchkit.suites import DESCRIPTIONS, SUITES, get, kind  # noqa: E402
 
 RESULTS = os.path.join(HERE, "results")
 

--- a/benchkit/harness/base.py
+++ b/benchkit/harness/base.py
@@ -48,6 +48,13 @@ class HarnessConfig:
     binary: str | None = None
     api_key: str | None = None
     extra_args: tuple[str, ...] = ()
+    #: live mode (issue #76): run the user's *daily* configuration as-is —
+    #: extensions, skills, MCP servers, settings files all included. Each
+    #: adapter drops its isolation flags accordingly and records which ones in
+    #: describe(). A live run measures a different thing from an isolated one,
+    #: and can contaminate the measurement if any part of the setup calls a
+    #: model other than the one being benchmarked.
+    live: bool = False
 
 
 class Harness:

--- a/benchkit/harness/claudecode.py
+++ b/benchkit/harness/claudecode.py
@@ -102,7 +102,11 @@ class ClaudeCodeHarness(Harness):
         self.base_url = _api_root(c.base_url) if c.base_url else None
         self.binary = c.binary or "claude"
         self.api_key = c.api_key or "sk-local"
-        self.tools = list(tools)
+        #: live mode: the user's daily setup — full tool set, skills, MCP servers
+        self.live = bool(c.live)
+        # live mode unpins the built-in tool set: Task/WebSearch and friends are
+        # part of what a real session can reach, caveat recorded in describe()
+        self.tools = [] if self.live else list(tools)
         self.effort = effort
         self.extra_args = list(c.extra_args)
 
@@ -185,8 +189,14 @@ class ClaudeCodeHarness(Harness):
             base_url=self.base_url,
             source="endpoint" if self.uses_endpoint else "claude-code-auth",
             api="anthropic-messages", tools=self.tools, effort=self.effort,
+            live=self.live,
             available=ok, detail=detail,
-            caveats=[
+            caveats=([
+                "live mode: Claude Code ran with your own settings, slash-command "
+                "skills and MCP servers enabled, and with every built-in tool "
+                "available. A subagent, hook or MCP server that calls another "
+                "model contaminates this measurement.",
+            ] if self.live else [
                 # Never let a missing number read as a cheap harness.
                 "reasoning_tokens is always 0: Claude Code reports thinking tokens "
                 "in usage.output_tokens_details.thinking_tokens, which this "
@@ -197,7 +207,7 @@ class ClaudeCodeHarness(Harness):
                 "Built-in tools are pinned to " + ",".join(self.tools) +
                 "; Task/Workflow/WebSearch/WebFetch are disabled because they can "
                 "reach other models or outside context.",
-            ],
+            ]),
         )
 
     # --- workspace ------------------------------------------------------
@@ -231,12 +241,14 @@ class ClaudeCodeHarness(Harness):
             "--output-format", "stream-json",
             "--verbose",                 # required for stream-json in print mode
             "--permission-mode", "bypassPermissions",  # throwaway temp workspace
-            "--bare",                    # no hooks/plugins/auto-memory/CLAUDE.md
-            "--disable-slash-commands",  # no user-installed skills
-            "--strict-mcp-config",
-            "--mcp-config", '{"mcpServers":{}}',
+            *([] if self.live else [
+                "--bare",                    # no hooks/plugins/auto-memory/CLAUDE.md
+                "--disable-slash-commands",  # no user-installed skills
+                "--strict-mcp-config",
+                "--mcp-config", '{"mcpServers":{}}',
+                "--setting-sources", "",     # ignore user/project/local settings
+            ]),                              # live mode keeps all of these (#76)
             "--no-session-persistence",  # no state between tasks
-            "--setting-sources", "",     # ignore user/project/local settings
         ]
         if self.tools:
             argv += ["--tools", *self.tools]

--- a/benchkit/harness/opencode.py
+++ b/benchkit/harness/opencode.py
@@ -56,6 +56,8 @@ class OpenCodeHarness(Harness):
         self.variant = variant
         self.api_key = c.api_key
         self.extra_args = list(c.extra_args)
+        #: live mode: the user's daily setup — plugins enabled (--pure dropped)
+        self.live = bool(c.live)
 
     @property
     def uses_endpoint(self):
@@ -141,11 +143,18 @@ class OpenCodeHarness(Harness):
 
     def describe(self):
         ok, detail = self.available()
-        return dict(harness="opencode", provider=self.provider, model=self.model,
-                    model_spec=self.model_spec,
-                    source="endpoint" if self.uses_endpoint else "opencode-config",
-                    base_url=self.base_url, variant=self.variant,
-                    available=ok, detail=detail)
+        d = dict(harness="opencode", provider=self.provider, model=self.model,
+                 model_spec=self.model_spec,
+                 source="endpoint" if self.uses_endpoint else "opencode-config",
+                 base_url=self.base_url, variant=self.variant, live=self.live,
+                 available=ok, detail=detail)
+        if self.live:
+            d["disabled_isolation"] = ["--pure"]
+            d["caveats"] = [
+                "live mode: opencode ran with external plugins enabled. A plugin "
+                "that reaches another model contaminates this measurement.",
+            ]
+        return d
 
     # --- workspace ------------------------------------------------------
     #: written next to the workspace, not into it — but excluded defensively
@@ -208,7 +217,7 @@ class OpenCodeHarness(Harness):
             "--dir", workdir,
             "--format", "json",
             "--auto",     # approve tool use; the workspace is a throwaway temp dir
-            "--pure",     # no external plugins — they can reach other models
+            *([] if self.live else ["--pure"]),   # live mode keeps the user's plugins (#76)
             "-m", self.model_spec,
         ]
         if self.variant:

--- a/benchkit/harness/pi.py
+++ b/benchkit/harness/pi.py
@@ -99,6 +99,8 @@ class PiHarness(Harness):
         self.agent_dir = agent_dir or os.environ.get("PI_CODING_AGENT_DIR")
         self.api_key = c.api_key
         self.extra_args = list(c.extra_args)
+        #: live mode: the user's daily setup — extensions and context files on
+        self.live = bool(c.live)
 
     @property
     def uses_endpoint(self):
@@ -240,10 +242,22 @@ class PiHarness(Harness):
 
     def describe(self):
         ok, detail = self.available()
-        return dict(harness="pi", provider=self.provider, model=self.model,
-                    model_spec=self.model_spec, base_url=self.base_url,
-                    source="endpoint" if self.uses_endpoint else "pi-catalogue",
-                    available=ok, detail=detail)
+        d = dict(harness="pi", provider=self.provider, model=self.model,
+                 model_spec=self.model_spec, base_url=self.base_url,
+                 source="endpoint" if self.uses_endpoint else "pi-catalogue",
+                 live=self.live,
+                 available=ok, detail=detail)
+        if self.live:
+            # AGENTS.md guardrail: extensions can call other models. A live run
+            # must say which isolation was dropped so nobody reads its score as
+            # a measurement of the benchmarked model alone.
+            d["disabled_isolation"] = ["--no-extensions", "--no-context-files"]
+            d["caveats"] = [
+                "live mode: pi ran with your own extensions and context files "
+                "(AGENTS.md/CLAUDE.md) enabled. An extension that calls another "
+                "model contaminates this measurement.",
+            ]
+        return d
 
     @property
     def model_spec(self):
@@ -327,8 +341,9 @@ class PiHarness(Harness):
             "--thinking", THINKING_LEVELS[bool(thinking)],
             "--mode", "json",
             "--no-session",         # no state carried between tasks
-            "--no-context-files",   # do not discover AGENTS.md/CLAUDE.md above the temp dir
-            "--no-extensions",      # extensions can call other models — see module docstring
+            # isolation is dropped in live mode (#76): extensions and context
+            # files are part of the user's setup there
+            *([] if self.live else ["--no-context-files", "--no-extensions"]),
             "--approve",            # trust the temp workspace, do not block on a prompt
         ] + self.extra_args
 

--- a/benchkit/report.py
+++ b/benchkit/report.py
@@ -500,7 +500,7 @@ def _raw_data_section(runs, labels):
 
 
 def build(runs, title, question=None, verdict=None, notes=None, short_labels=None,
-          setups=False):
+          setups=False, advice=False):
     """runs: list of loaded result dicts. Returns Markdown source."""
     labels = [_label(r) for r in runs]
     short = short_labels or (_setup_short(runs) if setups
@@ -527,6 +527,14 @@ def build(runs, title, question=None, verdict=None, notes=None, short_labels=Non
     if notes:
         out.append("## Reading the numbers\n")
         out.append(notes.strip() + "\n")
+
+    if advice:
+        # `bench setup run` stamps this on its report (issue #76): actionable
+        # suggestions derived from each run's own numbers.
+        for r in runs:
+            from . import advice as advice_mod
+            out.extend(advice_mod.section(r["summary"],
+                                          title="Suggestions — " + _label(r)))
 
     out.extend(_caveats_section(cfg0, samples, samples_same, agentic))
     out.extend(_raw_data_section(runs, labels))

--- a/docs/HARNESSES.md
+++ b/docs/HARNESSES.md
@@ -67,6 +67,35 @@ ollama-qwen3-coder-latest think-OFF` — because benchmarking two models through
 the ordinary case, and a file named after the harness alone would overwrite one run with the
 other.
 
+## Benchmark your live setup (`bench setup`)
+
+`bench harness run` isolates on purpose: pi runs with `--no-extensions`, opencode with
+`--pure`, Claude Code without skills or MCP servers — so the *model* is what varies.
+Sometimes the opposite question is the interesting one: **is my daily setup any good, and
+what should I change about it?**
+
+```bash
+./bench setup --harness pi --suite agentic-hard
+```
+
+`bench setup run` is `bench harness run` in **live mode**: every isolation flag is dropped
+and the harness runs exactly as you experience it — extensions, slash-command skills,
+MCP servers, settings files and (for Claude Code) the full built-in tool set all included.
+Nothing to reconfigure; point it at the repo and go. The result json lands in `results/`
+as usual, and a `REPORT-live.md` is written beside it ending in a **Suggestions** section:
+heuristic advice derived from the run's own numbers — context bloat traced back to installed
+skills/MCP servers, turn-limit hits pointing at missing tools, low valid-call rates pointing
+at schema mismatches, and so on.
+
+**The contamination caveat, stated once more:** a live setup can contain components that
+call other models (pi extensions and advisor tools are the usual offenders). A live-mode
+score measures the *whole setup*, whatever models it actually used. Every live result file
+records which isolation flags were disabled and carries that caveat in its metadata; do not
+quote a live number as a model number.
+
+Live results stamp `live` in both the config metadata and the label (`pi live prov-model
+think-OFF`), so they sort apart from isolated runs when reports compare setups.
+
 ## What stays the same
 
 Scoring. A task is still solved when `check(ws)` says the final workspace is right, and

--- a/tests/test_live_setup.py
+++ b/tests/test_live_setup.py
@@ -1,0 +1,195 @@
+"""Live-mode harness runs (issue #76): isolation dropped, contamination recorded.
+
+`bench setup` measures the user's daily configuration as-is. The contract under
+test: each adapter drops its own isolation flags in live mode, keeps them
+otherwise, and a live run always says so in describe() — an unlabelled live run
+would let a contaminated score be read as a clean one.
+"""
+import pytest
+
+from benchkit import advice, report
+from benchkit.harness import HarnessConfig
+
+
+# --- pi -------------------------------------------------------------------
+def test_pi_isolated_keeps_flags():
+    from benchkit.harness.pi import PiHarness
+    h = PiHarness(HarnessConfig(model="m"))
+    argv = " ".join(h._argv("p", False))
+    assert "--no-extensions" in argv
+    assert "--no-context-files" in argv
+
+
+def test_pi_live_drops_isolation_and_records_it():
+    from benchkit.harness.pi import PiHarness
+    h = PiHarness(HarnessConfig(model="m", live=True))
+    argv = " ".join(h._argv("p", False))
+    assert "--no-extensions" not in argv
+    assert "--no-context-files" not in argv
+    d = h.describe()
+    assert d["live"] is True
+    assert "--no-extensions" in d["disabled_isolation"]
+    assert d["caveats"]
+
+
+# --- opencode ---------------------------------------------------------------
+def test_opencode_isolated_keeps_pure():
+    from benchkit.harness.opencode import OpenCodeHarness
+    h = OpenCodeHarness(HarnessConfig(model="p/m"))
+    assert "--pure" in h._argv("p", "/tmp")
+
+
+def test_opencode_live_drops_pure_and_records_it():
+    from benchkit.harness.opencode import OpenCodeHarness
+    h = OpenCodeHarness(HarnessConfig(model="p/m", live=True))
+    assert "--pure" not in h._argv("p", "/tmp")
+    d = h.describe()
+    assert d["live"] is True
+    assert "--pure" in d["disabled_isolation"]
+
+
+# --- claude-code --------------------------------------------------------------
+def test_claudecode_isolated_pins_tools():
+    from benchkit.harness.claudecode import ClaudeCodeHarness
+    h = ClaudeCodeHarness(HarnessConfig(model="m"))
+    argv = " ".join(h._argv("p"))
+    for flag in ("--bare", "--disable-slash-commands", "--strict-mcp-config",
+                 "--setting-sources"):
+        assert flag in argv
+    assert "--tools" in argv
+
+
+def test_claudecode_live_unpins_everything_and_records_it():
+    from benchkit.harness.claudecode import ClaudeCodeHarness
+    h = ClaudeCodeHarness(HarnessConfig(model="m", live=True))
+    argv = " ".join(h._argv("p"))
+    for flag in ("--bare", "--disable-slash-commands", "--strict-mcp-config",
+                 "--mcp-config", "--setting-sources"):
+        assert flag not in argv
+    assert "--tools" not in argv
+    d = h.describe()
+    assert d["live"] is True
+    assert d["tools"] == []
+    assert d["caveats"]
+
+
+def test_claudecode_session_persistence_survives_live_mode():
+    # no-session-persistence is benchmark hygiene, not isolation: tasks must
+    # never share state even when the user's setup is live.
+    from benchkit.harness.claudecode import ClaudeCodeHarness
+    h = ClaudeCodeHarness(HarnessConfig(model="m", live=True))
+    assert "--no-session-persistence" in h._argv("p")
+
+
+# --- advice -------------------------------------------------------------------
+def _summary(**over):
+    s = dict(kind="agentic", pass_at_1=0.8, agent_score=0.7, mean_efficiency=0.9,
+             mean_input_tokens=10_000, hit_turn_limit=0,
+             wall_seconds=10.0, tasks=8, generations=8,
+             stalled_no_tool_call=0, valid_call_rate=1.0, mean_par_calls=4.0,
+             mean_tool_calls=5.0, mean_reasoning_tokens=100, errored=0,
+             by_difficulty={"easy": 1.0, "hard": 0.8},
+             config={"extra": {}, "label": "test run", "thinking": False,
+                     "max_tokens": 0, "model": "m", "base_url": "", 
+                     "concurrency": 2, "samples": 1}, harness={})
+    s.update(over)
+    return s
+
+
+def test_advice_flags_context_bloat_on_high_input_tokens():
+    s = _summary(mean_input_tokens=80_000)
+    s["config"]["extra"]["live"] = True
+    tips = "\n".join(advice.build(s))
+    assert "input tokens" in tips
+    assert "MCP" in tips or "skills" in tips
+
+
+def test_advice_flags_turn_limit_and_stalls():
+    tips = advice.build(_summary(hit_turn_limit=2, stalled_no_tool_call=1))
+    joined = "\n".join(tips)
+    assert "turn limit" in joined
+    assert "no tool call" in joined
+
+
+def test_advice_flags_low_valid_call_rate_as_schema_mismatch():
+    joined = "\n".join(advice.build(_summary(valid_call_rate=0.5)))
+    assert "tool-call" in joined
+
+
+def test_advice_silent_on_healthy_run():
+    tips = [t for t in advice.build(_summary()) if "live-mode" not in t]
+    assert tips == []
+
+
+def test_advice_section_has_fallback_for_healthy_run():
+    out = advice.section(_summary())
+    text = "\n".join(out)
+    assert text.startswith("## Suggestions")
+    assert "healthy" in text
+
+
+def test_advice_reads_live_flag_from_config_or_harness_block():
+    s = _summary(config={"extra": {"live": True}})
+    assert advice._is_live(s) is True
+    s2 = _summary(harness={"live": True})
+    assert advice._is_live(s2) is True
+
+
+# --- report / cli wiring --------------------------------------------------------
+def _result_file(tmp_path):
+    import json
+    summary = _summary(mean_input_tokens=90_000)
+    summary["config"]["extra"]["live"] = True
+    p = tmp_path / "r.json"
+    p.write_text(json.dumps(dict(summary=summary, results=[])))
+    return str(p)
+
+
+@pytest.fixture(autouse=True)
+def _fake_paths(monkeypatch):
+    monkeypatch.setattr(report, "_raw_data_section",
+                        lambda runs, labels: ["\n## Raw data\n"])
+    monkeypatch.setattr(report, "_setup_section",
+                        lambda S, short: ([""], 1, True))
+    monkeypatch.setattr(report, "_charts_section", lambda *a: [])
+    monkeypatch.setattr(report, "_difficulty_section", lambda S, labels: [])
+    monkeypatch.setattr(report, "_disagreement_section",
+                        lambda *a, **k: [])
+    monkeypatch.setattr(report, "_caveats_section", lambda *a, **k: [])
+
+
+def test_report_build_with_advice_includes_suggestions(tmp_path):
+    md = report.build([report.load(_result_file(tmp_path))], title="t",
+                      advice=True)
+    assert "## Suggestions" in md
+    assert "MCP" in md or "skills" in md
+
+
+def test_report_build_without_advice_omits_section(tmp_path):
+    md = report.build([report.load(_result_file(tmp_path))], title="t")
+    assert "Suggestions" not in md
+
+
+def test_cli_parser_accepts_setup_subcommand():
+    from benchkit.cli import _build_parser
+    args = _build_parser().parse_args(
+        ["setup", "--harness", "pi", "--suite", "agentic-hard"])
+    assert args.func.__name__ == "cmd_setup"
+    assert args.suite == "agentic-hard"
+
+
+def test_harness_config_stamps_live_metadata():
+    """The live stamp is what makes a result comparable/attributable later."""
+    from benchkit import runner
+    from benchkit.cli import _harness_config
+
+    class H:
+        name = "pi"
+        model_spec = "prov/m"
+
+    cfg = _harness_config(type("A", (), {
+        "label": "", "thinking": False, "samples": 1,
+        "concurrency": 2, "test_timeout": 60})(), H(), "(harness)", live=True)
+    assert cfg.extra["live"] is True
+    assert cfg.label.startswith("pi live ")
+    assert isinstance(cfg, runner.Config)

--- a/tests/test_live_setup.py
+++ b/tests/test_live_setup.py
@@ -5,7 +5,7 @@ test: each adapter drops its own isolation flags in live mode, keeps them
 otherwise, and a live run always says so in describe() — an unlabelled live run
 would let a contaminated score be read as a clean one.
 """
-import pytest
+from unittest.mock import patch
 
 from benchkit import advice, report
 from benchkit.harness import HarnessConfig
@@ -136,37 +136,47 @@ def test_advice_reads_live_flag_from_config_or_harness_block():
 
 
 # --- report / cli wiring --------------------------------------------------------
-def _result_file(tmp_path):
+def _result_file(tmp_path=None):
     import json
+    import pathlib
+    import tempfile
+
     summary = _summary(mean_input_tokens=90_000)
     summary["config"]["extra"]["live"] = True
-    p = tmp_path / "r.json"
+    base = pathlib.Path(tmp_path) if tmp_path is not None else pathlib.Path(tempfile.mkdtemp())
+    p = base / "r.json"
     p.write_text(json.dumps(dict(summary=summary, results=[])))
     return str(p)
 
 
-@pytest.fixture(autouse=True)
-def _fake_paths(monkeypatch):
-    monkeypatch.setattr(report, "_raw_data_section",
-                        lambda runs, labels: ["\n## Raw data\n"])
-    monkeypatch.setattr(report, "_setup_section",
-                        lambda S, short: ([""], 1, True))
-    monkeypatch.setattr(report, "_charts_section", lambda *a: [])
-    monkeypatch.setattr(report, "_difficulty_section", lambda S, labels: [])
-    monkeypatch.setattr(report, "_disagreement_section",
-                        lambda *a, **k: [])
-    monkeypatch.setattr(report, "_caveats_section", lambda *a, **k: [])
+def _patched_report_build(*args, **kwargs):
+    """Helper that patches report sections that require heavy fixtures."""
+    patches = [
+        patch.object(report, "_raw_data_section", lambda runs, labels: ["\n## Raw data\n"]),
+        patch.object(report, "_setup_section", lambda S, short: ([""], 1, True)),
+        patch.object(report, "_charts_section", lambda *a: []),
+        patch.object(report, "_difficulty_section", lambda S, labels: []),
+        patch.object(report, "_disagreement_section", lambda *a, **k: []),
+        patch.object(report, "_caveats_section", lambda *a, **k: []),
+    ]
+    for p in patches:
+        p.start()
+    try:
+        return report.build(*args, **kwargs)
+    finally:
+        for p in patches:
+            p.stop()
 
 
-def test_report_build_with_advice_includes_suggestions(tmp_path):
-    md = report.build([report.load(_result_file(tmp_path))], title="t",
-                      advice=True)
+def test_report_build_with_advice_includes_suggestions(tmp_path=None):
+    md = _patched_report_build([report.load(_result_file(tmp_path))], title="t",
+                               advice=True)
     assert "## Suggestions" in md
     assert "MCP" in md or "skills" in md
 
 
-def test_report_build_without_advice_omits_section(tmp_path):
-    md = report.build([report.load(_result_file(tmp_path))], title="t")
+def test_report_build_without_advice_omits_section(tmp_path=None):
+    md = _patched_report_build([report.load(_result_file(tmp_path))], title="t")
     assert "Suggestions" not in md
 
 


### PR DESCRIPTION
Closes #76

## Summary

Adds a one-command way to benchmark an agent's **live harness setup** — skills, MCP servers, extensions and all — from inside the harness the user already works in, producing a quantitative report plus evidence-based improvement suggestions.

## Approach

Option 2 — Balanced: opt-in `live` mode on each harness adapter (isolation flags dropped only when explicitly requested, with contamination caveats recorded), a new `bench setup run` CLI subcommand reusing the existing scoring/append-only-results pipeline, a pure-heuristic advice module (`benchkit/advice.py`) feeding a Suggestions section into the standard report, per-harness skill entry points (`.pi/skills/bench-setup`, `.opencode/command/bench-setup.md`), and docs.

## Decision Record

- **Root cause:** benchmarks existed for models only; nothing measured "this harness + this config as used daily", so setup quality was unmeasurable.
- **Options considered:** Option 1 — Minimal: live-mode flag only; Option 2 — Balanced: live mode + skill entry points + advice section; Option 3 — Comprehensive: unified setup registry + LLM-scored advice + sweep integration
- **Options rejected:** Option 1 — leaves two acceptance criteria unmet (in-harness entry point, improvement suggestions); Option 3 — scope far exceeds the issue; sweep integration and LLM advice can follow incrementally
- **Selected option:** Option 2 — Balanced
- **Residual risk:** live mode intentionally disables harness isolation — every live report stamps disabled_isolation + a model-contamination caveat; no e2e run against real installed harness binaries in CI (would execute model-driven agents)
- **Design-confirm:** confirmed Option 2 at design-confirm checkpoint (complexity: L)

Analyzed at: `feat/76-harness-setup-benchmark @ 53b3258` (2026-08-25)

## Changes

| File | Change |
|------|--------|
| `benchkit/harness/base.py` | Opt-in `live: bool = False` on HarnessConfig |
| `benchkit/harness/pi.py` | Live mode drops `--no-context-files`/`--no-extensions`; describe() records disabled flags + caveats |
| `benchkit/harness/opencode.py` | Live mode drops `--pure`; same recording |
| `benchkit/harness/claudecode.py` | Live mode drops bare/slash/MCP/tool-pinning isolation; keeps `--no-session-persistence`; same recording |
| `benchkit/cli.py` | New `bench setup` subcommand forcing live; `live` label prefix + metadata stamping; auto-writes append-only `REPORT-live.md` |
| `benchkit/advice.py` | New heuristic suggestion engine over existing summary signals (token bloat, turn-limit stalls, call-rate, par efficiency) |
| `benchkit/report.py` | `build(..., advice=True)` appends per-run Suggestions section |
| `.pi/skills/bench-setup/SKILL.md` | In-pi entry point skill |
| `.opencode/command/bench-setup.md` | opencode command entry point |
| `docs/HARNESSES.md` | "Benchmark your live setup" section incl. contamination caveat |
| `tests/test_live_setup.py` | 18 unit tests covering adapters, advice, report, CLI wiring |

## Test Results

- Unit tests: 286 passed (18 new; full suite green)
- Integration tests: skipped — none configured
- E2e tests: skipped — would execute model code on host
- Build: passed
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Single command/skill invokable inside a running harness starts the benchmark | pass | `.pi/skills/bench-setup/SKILL.md`, `.opencode/command/bench-setup.md` → `./bench setup run` |
| Runs against live configuration without manual reconfiguration | pass | live mode in `benchkit/harness/{pi,opencode,claudecode}.py` keeps user's real config/env; `tests/test_live_setup.py` adapter flag-matrix tests |
| Quantitative scores comparable across setups | pass | existing scoring pipeline reused; `live` label prefix + metadata stamping in `_harness_run` |
| Actionable improvement suggestions (config, skills, MCP) | pass | `benchkit/advice.py` heuristics → Suggestions section via `report.build(advice=True)`; unit-tested |
| Append-only `results/` writes | pass | `_ensure_unique_path` used for result JSON and `REPORT-live.md`; reviewer verified |

<!-- gitissue:qa v1 head=53b3258f1db6f8cb33445eeb0ecc25e901e7435c profile=full cycles=1 review=clean tests=286@53b3258f1db6f8cb33445eeb0ecc25e901e7435c ui=none:clean -->